### PR TITLE
[feature] add multi-tool support in a single server, matching tool us…

### DIFF
--- a/verl_tool/servers/serve.py
+++ b/verl_tool/servers/serve.py
@@ -1,13 +1,12 @@
 import argparse
 import re
 import fire
-
-import torch
 import uvicorn
 import logging
 from fastapi import FastAPI, Request
 from fastapi.responses import JSONResponse
 from .tools import get_tool_cls
+from typing import List, Union
 
 logger = logging.getLogger(__name__)
 
@@ -15,7 +14,10 @@ logger = logging.getLogger(__name__)
 def parse_agent_request(data):
     trajectory_ids = data.get("trajectory_ids")
     actions = data.get("actions")
-    extra_data = data.get("extra_data") 
+    extra_data = data.get("extra_data")
+    assert len(trajectory_ids) == len(actions), f"Number of trajectory_ids ({len(trajectory_ids)}) does not match number of actions ({len(actions)})"
+    if not extra_data:
+        extra_data = [None for _ in range(len(actions))]
     
     parsed_agent_request = {
         "trajectory_ids": trajectory_ids,
@@ -24,23 +26,80 @@ def parse_agent_request(data):
     }
     return parsed_agent_request
 
+def get_tools_usage_instructions(tools):
+    usage_instructions = {}
+    for tool_type, tool in tools.items():
+        usage_instructions[tool_type] = tool.get_usage_inst()
+    message = "Your action did not match any of the available tools, please use one of the following tools: \n"
+    message += "\n".join([f"- {tool_type}: {usage_instructions[tool_type]}" for tool_type in usage_instructions])
+    return message
+
+def get_tool_type_for_action(tools, action):
+    if len(tools) == 1:
+        # if there is only one tool, always use that tool
+        return list(tools.keys())[0]
+    # if there are multiple tools, try to find the tool that matches the action
+    for tool_type, tool in tools.items():
+        _, valid = tool.parse_action(action)
+        if valid:
+            return tool_type
+    return None
+
+def get_multi_tool_observations(tools, trajectory_ids, actions, extra_data):
+    tool_type_each_action = [get_tool_type_for_action(tools, action) for action in actions]
+    # get observations for each tool
+    all_tool_types = set(tool_type_each_action)
+    all_observations = [None for _ in range(len(actions))]
+    all_dones = [False for _ in range(len(actions))]
+    all_valids = [False for _ in range(len(actions))]
+    for tool_type in all_tool_types:
+        tool = tools[tool_type]
+        tool_indices = [i for i, t in enumerate(tool_type_each_action) if t == tool_type]
+        if tool_type is None:
+            # not a single tool matched the action
+            observations = [get_tools_usage_instructions(tools) for _ in range(len(actions))]
+            dones = [False for _ in range(len(actions))]
+            valids = [False for _ in range(len(actions))]
+        else:
+            tool_trajectory_ids = [trajectory_ids[i] for i in tool_indices]
+            tool_actions = [actions[i] for i in tool_indices]
+            tool_extra_data = [extra_data[i] for i in tool_indices]
+            observations, dones, valids = tool.get_observations(tool_trajectory_ids, tool_actions, tool_extra_data)
+        for i, idx in enumerate(tool_indices):
+            all_observations[idx] = observations[i]
+            all_dones[idx] = dones[i]
+            all_valids[idx] = valids[i]
+    return all_observations, all_dones, all_valids
 
 def main(
     host: str = "0.0.0.0",
     port: int = 5000,
     num_workers: int = 1,
-    max_obs_length: int = 2048,
-    tool_type = "base",
+    tool_type: str = "base",
 ):
+    """
+    Start the server with the given tool type(s).
+    
+    Args:
+        host: The host address
+        port: The port number
+        num_workers: The number of workers
+        tool_type: The tool type(s) to use, separated by commas (default: base)
+
+    """
 
     app = FastAPI()
-    tool = get_tool_cls(tool_type)()
+    if isinstance(tool_type, str):
+        tool_type = (tool_type,)
+    
+    print(f"Starting server with tools: {tool_type}")
+    tools = {t_type: get_tool_cls(t_type)(num_workers=num_workers) for t_type in tool_type}
     
     @app.post("/get_observation")
     async def get_observation(request: Request):
         data = await request.json()
         parsed_data = parse_agent_request(data)
-        observations, dones, valids = tool.get_observations(**parsed_data)
+        observations, dones, valids = get_multi_tool_observations(tools, **parsed_data)
         result = {"observations": observations, "dones": dones, "valids": valids}
         logger.info(f"Sent JSON: {result}")
         return JSONResponse(result)

--- a/verl_tool/servers/tools/base.py
+++ b/verl_tool/servers/tools/base.py
@@ -39,6 +39,12 @@ class BaseTool:
         registered_tools[self.tool_type] = self.__class__
         self.env_cache = {}
     
+    def get_usage_inst(self):
+        """
+        Get the usage instructions for the tool
+        """
+        return "Base usage instructions"
+    
     def load_env(self, trajectory_id):
         """
         Load the environment for the given trajectory_id

--- a/verl_tool/servers/tools/python_code.py
+++ b/verl_tool/servers/tools/python_code.py
@@ -5,6 +5,9 @@ from .base import BaseTool, register_tool
 class PythonCodeTool(BaseTool):
     tool_type = "python_code"
     
+    def get_usage_inst(self):
+        return "Usage instructions for PythonCodeTool"
+    
     def parse_action(self, action:str):
         """
         Parse the raw action string (which is the llm response) into a actual action and it's contents


### PR DESCRIPTION
# Add multi-tool support in a single server

## Summary
This PR introduces the multi-tool support in a single server. By using `parse_action` to determine whether an action is valid for a specific tool to match the action with the tool. If no tools are matched, then it will automatically return the observation consisting of usage instructions of each tool `get_usage_inst()` to indicate what kind of tools are able to use.

## Testing
All tests have been completed successfully:
- ✅ Server connection testing
- ✅ tool matching testing using `base` and `piston` as the candidate tools.