### PR TITLE
verl tool math ready 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -293,7 +293,7 @@ tests/e2e/toy_examples/deepspeed/synchronous/output.txt
 # ckpt
 *.lock
 
-# data
+data/
 *.parquet
 
 
@@ -301,7 +301,6 @@ tests/e2e/toy_examples/deepspeed/synchronous/output.txt
 logs
 log
 outputs
-
-/test*
-/verl_step_records
-/state.json
+verl_checkpoints/
+verl_step_records/
+**/tmp.*

--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@ pip install uv # if not installed
 uv sync
 git submodule update --init --recursive
 source .venv/bin/activate
-uv pip install -e verl[vllm] # this shall use vllm==0.8.2 which uses the faster v1 engine 
+uv pip install -e verl[vllm]
+uv pip install vllm==0.8.1 # aligh with torl 
 uv pip install flash-attn --no-build-isolation
 ```
 

--- a/examples/train/torl/torl_1.5b_math_hard.sh
+++ b/examples/train/torl/torl_1.5b_math_hard.sh
@@ -1,7 +1,17 @@
-set -x
-train_data=data/math_hard/train.parquet
-val_data=data/math_hard/test.parquet
-model_name=Qwen/Qwen2.5-Math-7B
+export CUDA_VISIBLE_DEVICES=0,1,2,3
+export WANDB_API_KEY="31800be459915fc29628b8c03920c3b526d64109"
+
+n_gpus_per_node=4
+n_nodes=1
+rl_alg=grpo # gae(ppo) or grpo, if grpo, then better set n>1 otherwise the group norm can not be effective
+train_data=data/math_torl/train.parquet
+val_data=[data/math_torl/test.parquet,\
+data/math_torl/math500_test.parquet,\
+data/math_torl/aime24_test.parquet,\
+data/math_torl/aime25_test.parquet]
+model_name=Qwen/Qwen2.5-Math-1.5B
+# model_name=GAIR/ToRL-1.5B
+# model_name=/home/user/.cache/huggingface/hub/models--Qwen--Qwen2.5-Math-1.5B/snapshots/4a83ca6e4526a4f2da3aa259ec36c259f66b2ab2
 batch_size=128
 max_prompt_length=1024
 max_response_length=3072
@@ -10,24 +20,28 @@ lr=1e-6
 ppo_mini_batch_size=$batch_size
 strategy="fsdp_agent" # remove _agent for normal verl behavior
 kl_loss_coef=0.0
+kl_loss_type=low_var_kl
 kl_coef=0
 entropy_coeff=0
-rl_alg=grpo # gae(ppo) or grpo, if grpo, then better set n>1 otherwise the group norm can not be effective
-n_gpus_per_node=8
-n_nodes=1
-n=16
 
-max_obs_length=512
+# host=0.0.0.0
+# port=$(shuf -i 30000-31000 -n 1)
+# tool_server_url=http://$host:$port/get_observation
+# python -m verl_tool.servers.serve --host $host --port $port --tool_type "firejail_python_code" --workers_per_tool 32 &
+host=0.0.0.0
+port=30207
+tool_server_url=http://$host:$port/get_observation
+server_pid=$!
+echo "Server (pid=$server_pid) started at $tool_server_url"
+max_obs_length=256
+max_turns=1
+action_stop_tokens="\`\`\`output"
 temperature=1.0
 top_p=1.0
-action_stop_tokens="\`\`\`output"
-max_turns=1
-
-kl_loss_type=low_var_kl
-log_prob_micro_batch_size_per_gpu=2
+n_samples_per_prompts=16
 
 model_pretty_name=$(echo $model_name | tr '/' '_' | tr '[:upper:]' '[:lower:]')
-run_name="${reward_manager}-${strategy}-${model_pretty_name}-${rl_alg}-n${n}-b${batch_size}-t${temperature}-lr${lr}-$(date +%Y%m%d-%H%M%S)"
+run_name="${reward_manager}-${strategy}-${model_pretty_name}-${rl_alg}-n${n_samples_per_prompts}-b${batch_size}-t${temperature}-lr${lr}"
 export VERL_RUN_ID=$run_name
 
 # temp file for action tokens as verl cannot pass special strs as params
@@ -35,18 +49,8 @@ action_stop_tokens_file=$(mktemp)
 echo "$action_stop_tokens" > $action_stop_tokens_file
 echo "action_stop_tokens_file=$action_stop_tokens_file"
 
-host=0.0.0.0
-port=$(shuf -i 30000-31000 -n 1)
-tool_server_url=http://$host:$port/get_observation
-python -m verl_tool.servers.serve --host $host --port $port --tool_type "firejail_python_code" --workers_per_tool 32 &
-server_pid=$!
-echo "Server (pid=$server_pid) started at $tool_server_url"
-
-# actor_rollout_ref.rollout.enforce_eager=False \
-# actor_rollout_ref.rollout.free_cache_engine=False \
-
 # export VLLM_USE_V1=1
-PYTHONUNBUFFERED=1 python3 -m verl_tool.trainer.main_ppo \
+python3 -m verl_tool.trainer.main_ppo \
     algorithm.adv_estimator=$rl_alg \
     data.train_files=$train_data \
     data.val_files=$val_data \
@@ -54,9 +58,12 @@ PYTHONUNBUFFERED=1 python3 -m verl_tool.trainer.main_ppo \
     data.val_batch_size=2048 \
     data.max_prompt_length=$max_prompt_length \
     data.max_response_length=$max_response_length \
+    data.truncation='right' \
     reward_model.reward_manager=$reward_manager \
     actor_rollout_ref.model.path=$model_name \
     actor_rollout_ref.actor.optim.lr=$lr \
+    actor_rollout_ref.model.use_remove_padding=True \
+    actor_rollout_ref.actor.checkpoint.contents=['model','optimizer','extra','hf_model'] \
     actor_rollout_ref.actor.ppo_mini_batch_size=$ppo_mini_batch_size \
     actor_rollout_ref.actor.use_dynamic_bsz=True \
     actor_rollout_ref.actor.use_kl_loss=True \
@@ -72,15 +79,16 @@ PYTHONUNBUFFERED=1 python3 -m verl_tool.trainer.main_ppo \
     +actor_rollout_ref.agent.max_turns=$max_turns \
     +actor_rollout_ref.agent.num_gpus=$n_gpus_per_node \
     +actor_rollout_ref.agent.action_stop_tokens=$action_stop_tokens_file \
-    actor_rollout_ref.rollout.log_prob_micro_batch_size_per_gpu=$log_prob_micro_batch_size_per_gpu \
-    actor_rollout_ref.rollout.tensor_model_parallel_size=2 \
-    actor_rollout_ref.rollout.gpu_memory_utilization=0.6 \
+    actor_rollout_ref.rollout.tensor_model_parallel_size=1 \
+    actor_rollout_ref.rollout.name=vllm \
     actor_rollout_ref.rollout.temperature=$temperature \
-    actor_rollout_ref.rollout.top_k=-1 \
-    actor_rollout_ref.rollout.n=$n \
     actor_rollout_ref.rollout.top_p=$top_p \
-    actor_rollout_ref.ref.log_prob_use_dynamic_bsz=False \
-    actor_rollout_ref.ref.log_prob_micro_batch_size_per_gpu=$log_prob_micro_batch_size_per_gpu \
+    actor_rollout_ref.rollout.gpu_memory_utilization=0.85 \
+    actor_rollout_ref.rollout.n=$n_samples_per_prompts \
+    actor_rollout_ref.rollout.log_prob_use_dynamic_bsz=True \
+    actor_rollout_ref.rollout.max_num_seqs=1024 \
+    actor_rollout_ref.ref.log_prob_use_dynamic_bsz=True \
+    actor_rollout_ref.ref.fsdp_config.param_offload=True \
     critic.optim.lr=1e-5 \
     critic.strategy=$strategy \
     critic.model.path=$model_name \
@@ -89,15 +97,14 @@ PYTHONUNBUFFERED=1 python3 -m verl_tool.trainer.main_ppo \
     trainer.logger=['console','wandb'] \
     trainer.project_name='torl' \
     trainer.experiment_name=$run_name \
-    trainer.val_before_train=False \
+    trainer.val_before_train=True \
     trainer.default_hdfs_dir=null \
     trainer.n_gpus_per_node=$n_gpus_per_node \
     trainer.nnodes=$n_nodes \
-    +trainer.remove_previous_ckpt_in_save=True \
     trainer.save_freq=10 \
     trainer.test_freq=10 \
+    +trainer.remove_previous_ckpt_in_save=False \
+    trainer.default_local_dir=verl_checkpoints/${run_name} \
+    trainer.resume_mode=disable \
+    trainer.resume_from_path=null \
     trainer.total_epochs=10
-
-
-pkill -P -9 $server_pid
-kill -9 $kill $server_pid

--- a/examples/train/torl/torl_1.5b_math_hard_vol.sh
+++ b/examples/train/torl/torl_1.5b_math_hard_vol.sh
@@ -1,7 +1,12 @@
+export CUDA_VISIBLE_DEVICES=6
+export WANDB_API_KEY="31800be459915fc29628b8c03920c3b526d64109"
+export HF_TOKEN="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"
+
 set -x
+rl_alg=grpo # gae(ppo) or grpo, if grpo, then better set n>1 otherwise the group norm can not be effective
 train_data=data/math_hard/train.parquet
 val_data=data/math_hard/test.parquet
-model_name=Qwen/Qwen2.5-Math-7B
+model_name=/map-vepfs/models/Qwen--Qwen2.5-Math-1.5B/snapshots/4a83ca6e4526a4f2da3aa259ec36c259f66b2ab2
 batch_size=128
 max_prompt_length=1024
 max_response_length=3072
@@ -10,40 +15,33 @@ lr=1e-6
 ppo_mini_batch_size=$batch_size
 strategy="fsdp_agent" # remove _agent for normal verl behavior
 kl_loss_coef=0.0
+kl_loss_type=low_var_kl
 kl_coef=0
 entropy_coeff=0
-rl_alg=grpo # gae(ppo) or grpo, if grpo, then better set n>1 otherwise the group norm can not be effective
-n_gpus_per_node=8
-n_nodes=1
-n=16
 
+host=0.0.0.0
+port=30268
+tool_server_url=http://$host:$port/get_observation
+# python -m verl_tool.servers.serve --host $host --port $port --tool_type "firejail_python_code" --workers_per_tool 32 &
+server_pid=$!
+echo "Server (pid=$server_pid) started at $tool_server_url"
 max_obs_length=512
+max_turns=1
+n_gpus_per_node=1
+n_nodes=1
+action_stop_tokens="\`\`\`output"
 temperature=1.0
 top_p=1.0
-action_stop_tokens="\`\`\`output"
-max_turns=1
-
-kl_loss_type=low_var_kl
-log_prob_micro_batch_size_per_gpu=2
+n_samples_per_prompts=16
 
 model_pretty_name=$(echo $model_name | tr '/' '_' | tr '[:upper:]' '[:lower:]')
-run_name="${reward_manager}-${strategy}-${model_pretty_name}-${rl_alg}-n${n}-b${batch_size}-t${temperature}-lr${lr}-$(date +%Y%m%d-%H%M%S)"
+run_name="${reward_manager}-${strategy}-${model_pretty_name}-${rl_alg}-n${n_samples_per_prompts}-b${batch_size}-t${temperature}-lr${lr}-$(date +%Y%m%d-%H%M%S)"
 export VERL_RUN_ID=$run_name
 
 # temp file for action tokens as verl cannot pass special strs as params
 action_stop_tokens_file=$(mktemp)
 echo "$action_stop_tokens" > $action_stop_tokens_file
 echo "action_stop_tokens_file=$action_stop_tokens_file"
-
-host=0.0.0.0
-port=$(shuf -i 30000-31000 -n 1)
-tool_server_url=http://$host:$port/get_observation
-python -m verl_tool.servers.serve --host $host --port $port --tool_type "firejail_python_code" --workers_per_tool 32 &
-server_pid=$!
-echo "Server (pid=$server_pid) started at $tool_server_url"
-
-# actor_rollout_ref.rollout.enforce_eager=False \
-# actor_rollout_ref.rollout.free_cache_engine=False \
 
 # export VLLM_USE_V1=1
 PYTHONUNBUFFERED=1 python3 -m verl_tool.trainer.main_ppo \
@@ -57,6 +55,7 @@ PYTHONUNBUFFERED=1 python3 -m verl_tool.trainer.main_ppo \
     reward_model.reward_manager=$reward_manager \
     actor_rollout_ref.model.path=$model_name \
     actor_rollout_ref.actor.optim.lr=$lr \
+    actor_rollout_ref.model.use_remove_padding=True \
     actor_rollout_ref.actor.ppo_mini_batch_size=$ppo_mini_batch_size \
     actor_rollout_ref.actor.use_dynamic_bsz=True \
     actor_rollout_ref.actor.use_kl_loss=True \
@@ -72,15 +71,16 @@ PYTHONUNBUFFERED=1 python3 -m verl_tool.trainer.main_ppo \
     +actor_rollout_ref.agent.max_turns=$max_turns \
     +actor_rollout_ref.agent.num_gpus=$n_gpus_per_node \
     +actor_rollout_ref.agent.action_stop_tokens=$action_stop_tokens_file \
-    actor_rollout_ref.rollout.log_prob_micro_batch_size_per_gpu=$log_prob_micro_batch_size_per_gpu \
-    actor_rollout_ref.rollout.tensor_model_parallel_size=2 \
-    actor_rollout_ref.rollout.gpu_memory_utilization=0.6 \
+    actor_rollout_ref.rollout.tensor_model_parallel_size=1 \
+    actor_rollout_ref.rollout.name=vllm \
     actor_rollout_ref.rollout.temperature=$temperature \
-    actor_rollout_ref.rollout.top_k=-1 \
-    actor_rollout_ref.rollout.n=$n \
     actor_rollout_ref.rollout.top_p=$top_p \
-    actor_rollout_ref.ref.log_prob_use_dynamic_bsz=False \
-    actor_rollout_ref.ref.log_prob_micro_batch_size_per_gpu=$log_prob_micro_batch_size_per_gpu \
+    actor_rollout_ref.rollout.gpu_memory_utilization=0.85 \
+    actor_rollout_ref.rollout.n=$n_samples_per_prompts \
+    actor_rollout_ref.rollout.log_prob_use_dynamic_bsz=True \
+    actor_rollout_ref.rollout.max_num_seqs=1024 \
+    actor_rollout_ref.ref.log_prob_use_dynamic_bsz=True \
+    actor_rollout_ref.ref.fsdp_config.param_offload=True \
     critic.optim.lr=1e-5 \
     critic.strategy=$strategy \
     critic.model.path=$model_name \
@@ -89,15 +89,17 @@ PYTHONUNBUFFERED=1 python3 -m verl_tool.trainer.main_ppo \
     trainer.logger=['console','wandb'] \
     trainer.project_name='torl' \
     trainer.experiment_name=$run_name \
-    trainer.val_before_train=False \
+    trainer.val_before_train=True \
     trainer.default_hdfs_dir=null \
     trainer.n_gpus_per_node=$n_gpus_per_node \
     trainer.nnodes=$n_nodes \
-    +trainer.remove_previous_ckpt_in_save=True \
     trainer.save_freq=10 \
-    trainer.test_freq=10 \
+    trainer.test_freq=5 \
+    +trainer.remove_previous_ckpt_in_save=True \
+    trainer.default_local_dir=verl_checkpoints/${run_name} \
+    trainer.resume_mode=auto \
+    trainer.resume_from_path=True \
     trainer.total_epochs=10
-
 
 pkill -P -9 $server_pid
 kill -9 $kill $server_pid

--- a/examples/train/torl/torl_7b_math_hard.sh
+++ b/examples/train/torl/torl_7b_math_hard.sh
@@ -1,33 +1,46 @@
-set -x
-train_data=data/math_hard/train.parquet
-val_data=data/math_hard/test.parquet
+export CUDA_VISIBLE_DEVICES=0,1,2,3,4,5,6,7
+export WANDB_API_KEY="31800be459915fc29628b8c03920c3b526d64109"
+
+n_gpus_per_node=8
+n_nodes=1
+rl_alg=grpo # gae(ppo) or grpo, if grpo, then better set n>1 otherwise the group norm can not be effective
+train_data=data/math_torl/train.parquet
+val_data=[data/math_torl/test.parquet,\
+data/math_torl/math500_test.parquet,\
+data/math_torl/aime24_test.parquet,\
+data/math_torl/aime25_test.parquet]
 model_name=Qwen/Qwen2.5-Math-7B
+# model_name=/home/user/.cache/huggingface/hub/models--Qwen--Qwen2.5-Math-1.5B/snapshots/4a83ca6e4526a4f2da3aa259ec36c259f66b2ab2
 batch_size=128
 max_prompt_length=1024
-max_response_length=3072
+max_response_length=2048
 reward_manager=torl
 lr=1e-6
 ppo_mini_batch_size=$batch_size
 strategy="fsdp_agent" # remove _agent for normal verl behavior
 kl_loss_coef=0.0
+kl_loss_type=low_var_kl
 kl_coef=0
 entropy_coeff=0
-rl_alg=grpo # gae(ppo) or grpo, if grpo, then better set n>1 otherwise the group norm can not be effective
-n_gpus_per_node=8
-n_nodes=1
-n=16
 
-max_obs_length=512
+# host=0.0.0.0
+# port=$(shuf -i 30000-31000 -n 1)
+# tool_server_url=http://$host:$port/get_observation
+# python -m verl_tool.servers.serve --host $host --port $port --tool_type "firejail_python_code" --workers_per_tool 32 &
+host=0.0.0.0
+port=30207
+tool_server_url=http://$host:$port/get_observation
+server_pid=$!
+echo "Server (pid=$server_pid) started at $tool_server_url"
+max_obs_length=256
+max_turns=1
+action_stop_tokens="\`\`\`output"
 temperature=1.0
 top_p=1.0
-action_stop_tokens="\`\`\`output"
-max_turns=1
-
-kl_loss_type=low_var_kl
-log_prob_micro_batch_size_per_gpu=2
+n_samples_per_prompts=16
 
 model_pretty_name=$(echo $model_name | tr '/' '_' | tr '[:upper:]' '[:lower:]')
-run_name="${reward_manager}-${strategy}-${model_pretty_name}-${rl_alg}-n${n}-b${batch_size}-t${temperature}-lr${lr}-$(date +%Y%m%d-%H%M%S)"
+run_name="${reward_manager}-${strategy}-${model_pretty_name}-${rl_alg}-n${n_samples_per_prompts}-b${batch_size}-t${temperature}-lr${lr}"
 export VERL_RUN_ID=$run_name
 
 # temp file for action tokens as verl cannot pass special strs as params
@@ -35,18 +48,8 @@ action_stop_tokens_file=$(mktemp)
 echo "$action_stop_tokens" > $action_stop_tokens_file
 echo "action_stop_tokens_file=$action_stop_tokens_file"
 
-host=0.0.0.0
-port=$(shuf -i 30000-31000 -n 1)
-tool_server_url=http://$host:$port/get_observation
-python -m verl_tool.servers.serve --host $host --port $port --tool_type "firejail_python_code" --workers_per_tool 32 &
-server_pid=$!
-echo "Server (pid=$server_pid) started at $tool_server_url"
-
-# actor_rollout_ref.rollout.enforce_eager=False \
-# actor_rollout_ref.rollout.free_cache_engine=False \
-
 # export VLLM_USE_V1=1
-PYTHONUNBUFFERED=1 python3 -m verl_tool.trainer.main_ppo \
+python3 -m verl_tool.trainer.main_ppo \
     algorithm.adv_estimator=$rl_alg \
     data.train_files=$train_data \
     data.val_files=$val_data \
@@ -54,9 +57,12 @@ PYTHONUNBUFFERED=1 python3 -m verl_tool.trainer.main_ppo \
     data.val_batch_size=2048 \
     data.max_prompt_length=$max_prompt_length \
     data.max_response_length=$max_response_length \
+    data.truncation='right' \
     reward_model.reward_manager=$reward_manager \
     actor_rollout_ref.model.path=$model_name \
+    actor_rollout_ref.actor.checkpoint.contents=['model','optimizer','extra','hf_model'] \
     actor_rollout_ref.actor.optim.lr=$lr \
+    actor_rollout_ref.model.use_remove_padding=True \
     actor_rollout_ref.actor.ppo_mini_batch_size=$ppo_mini_batch_size \
     actor_rollout_ref.actor.use_dynamic_bsz=True \
     actor_rollout_ref.actor.use_kl_loss=True \
@@ -64,6 +70,8 @@ PYTHONUNBUFFERED=1 python3 -m verl_tool.trainer.main_ppo \
     actor_rollout_ref.actor.kl_loss_coef=$kl_loss_coef \
     actor_rollout_ref.actor.kl_loss_type=$kl_loss_type \
     actor_rollout_ref.actor.entropy_coeff=$entropy_coeff \
+    actor_rollout_ref.actor.fsdp_config.param_offload=True \
+    actor_rollout_ref.actor.fsdp_config.optimizer_offload=True \
     +actor_rollout_ref.agent.tool_server_url=$tool_server_url \
     +actor_rollout_ref.agent.max_prompt_length=$max_prompt_length \
     +actor_rollout_ref.agent.max_response_length=$max_response_length \
@@ -72,15 +80,16 @@ PYTHONUNBUFFERED=1 python3 -m verl_tool.trainer.main_ppo \
     +actor_rollout_ref.agent.max_turns=$max_turns \
     +actor_rollout_ref.agent.num_gpus=$n_gpus_per_node \
     +actor_rollout_ref.agent.action_stop_tokens=$action_stop_tokens_file \
-    actor_rollout_ref.rollout.log_prob_micro_batch_size_per_gpu=$log_prob_micro_batch_size_per_gpu \
-    actor_rollout_ref.rollout.tensor_model_parallel_size=2 \
-    actor_rollout_ref.rollout.gpu_memory_utilization=0.6 \
+    actor_rollout_ref.rollout.tensor_model_parallel_size=1 \
+    actor_rollout_ref.rollout.name=vllm \
     actor_rollout_ref.rollout.temperature=$temperature \
-    actor_rollout_ref.rollout.top_k=-1 \
-    actor_rollout_ref.rollout.n=$n \
     actor_rollout_ref.rollout.top_p=$top_p \
-    actor_rollout_ref.ref.log_prob_use_dynamic_bsz=False \
-    actor_rollout_ref.ref.log_prob_micro_batch_size_per_gpu=$log_prob_micro_batch_size_per_gpu \
+    actor_rollout_ref.rollout.gpu_memory_utilization=0.85 \
+    actor_rollout_ref.rollout.n=$n_samples_per_prompts \
+    actor_rollout_ref.rollout.log_prob_use_dynamic_bsz=True \
+    actor_rollout_ref.rollout.max_num_seqs=1024 \
+    actor_rollout_ref.ref.log_prob_use_dynamic_bsz=True \
+    actor_rollout_ref.ref.fsdp_config.param_offload=True \
     critic.optim.lr=1e-5 \
     critic.strategy=$strategy \
     critic.model.path=$model_name \
@@ -93,11 +102,10 @@ PYTHONUNBUFFERED=1 python3 -m verl_tool.trainer.main_ppo \
     trainer.default_hdfs_dir=null \
     trainer.n_gpus_per_node=$n_gpus_per_node \
     trainer.nnodes=$n_nodes \
-    +trainer.remove_previous_ckpt_in_save=True \
     trainer.save_freq=10 \
     trainer.test_freq=10 \
+    +trainer.remove_previous_ckpt_in_save=False \
+    trainer.default_local_dir=verl_checkpoints/${run_name} \
+    trainer.resume_mode=disable \
+    trainer.resume_from_path=null \
     trainer.total_epochs=10
-
-
-pkill -P -9 $server_pid
-kill -9 $kill $server_pid

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,5 +21,5 @@ acecoder = [
     "AceCoder @ git+https://github.com/TIGER-AI-Lab/AceCoder.git@dev",
 ]
 torl = [
-    "math-verify[antlr4-9-3]>=0.7.0",
+    "math-verify",
 ]

--- a/verl_tool/servers/tools/firejail.py
+++ b/verl_tool/servers/tools/firejail.py
@@ -1,0 +1,54 @@
+# Firejail is a local sandbox and strikes the best balance of reliability, scalability, and security
+# https://github.com/netblue30/firejail
+# sudo add-apt-repository ppa:deki/firejail
+# sudo apt-get update
+# sudo apt-get install firejail firejail-profiles
+import os
+import subprocess
+import timeout_decorator
+
+TIMEOUT = 5
+
+@timeout_decorator.timeout(TIMEOUT, use_signals=False)
+def _code_exec_firejail(code, stdin: str = None):
+    env = os.environ.copy()
+    env["OPENBLAS_NUM_THREADS"] = "1"
+    if "PYTHONPATH" in env:
+        del env["PYTHONPATH"] # avoid importing wrong stuff
+
+    # Build the firejail command with resource limits and cleanup options
+    command = [
+        "firejail",
+        "--private",
+        "--quiet",
+        "--seccomp=socket",
+        "--profile=pip",
+        "--rlimit-nproc=32",
+        "--rlimit-nofile=32",
+        "--rlimit-fsize=2m",  # Limit file size
+        "--rlimit-as=4096m",
+    ]
+
+    command.extend(["python3", "-c", code])
+    result = subprocess.run(command,
+                            input=stdin.encode() if stdin else None,
+                            stdout=subprocess.PIPE,
+                            stderr=subprocess.PIPE,
+                            env=env,
+                            check=False)
+    stdout = result.stdout.decode()
+    stderr = result.stderr.decode().strip()
+
+    if result.returncode == 0:
+        return stdout
+    return f"{stdout}\nERROR:\n{stderr}"
+
+def code_exec_firejail(code, stdin: str = None):
+    try:
+        return _code_exec_firejail(code, stdin)
+    except Exception as e:
+        return f"Exception: {e}"
+
+if __name__ == "__main__":
+    print(code_exec_firejail("print('Hello, World!')"))
+

--- a/verl_tool/trainer/ppo/ray_trainer.py
+++ b/verl_tool/trainer/ppo/ray_trainer.py
@@ -86,6 +86,7 @@ class AgentRayPPOTrainer(RayPPOTrainer):
 
         for epoch in range(self.config.trainer.total_epochs):
             for batch_dict in self.train_dataloader:
+                print(f'epoch {epoch}, step {self.global_steps}')
                 metrics = {}
                 timing_raw = {}
 


### PR DESCRIPTION
Currently, we can run the Math 1.5B and 7B models on 4 * A100 80G and 8 * A100 80G setups, respectively, directly using `firejail` without a server to call Python. I will develop the mix way on this branch further. 