### PR TITLE
[trainer] support for fallback to original async server

### DIFF
--- a/verl_tool/trainer/ppo/ray_trainer.py
+++ b/verl_tool/trainer/ppo/ray_trainer.py
@@ -110,7 +110,7 @@ class AgentRayPPOTrainer(RayPPOTrainer):
         # create async rollout manager and request scheduler
         self.async_rollout_mode = False
         if self.config.actor_rollout_ref.rollout.mode == "async":
-            if self.config.actor_rollout_ref.actor.enable_agent:
+            if self.config.actor_rollout_ref.agent.enable_agent:
                 from verl_tool.workers.rollout.async_server import VerlToolAsyncLLMServerManager as AsyncLLMServerManager # added by verl-tool
             else:
                 from verl.workers.rollout.async_server import AsyncLLMServerManager


### PR DESCRIPTION
Added support for fallback to original async server in the case that no tool use is needed, similar to support for calling original `generate_sequences` instead of `AgentActorManager.run_llm_loop`


`verl_tool/trainer/ppo/ray_trainer.py`
```python      
        if self.config.actor_rollout_ref.rollout.mode == "async":
            if self.config.actor_rollout_ref.actor.enable_agent:
                from verl_tool.workers.rollout.async_server import VerlToolAsyncLLMServerManager as AsyncLLMServerManager # added by verl-tool
            else:
                from verl.workers.rollout.async_server import AsyncLLMServerManager

            self.async_rollout_mode = True
            self.async_rollout_manager = AsyncLLMServerManager(
                config=self.config,
                worker_group=self.actor_rollout_wg,
            )
```