### PR TITLE
Fix double repeat for val n

### DIFF
--- a/verl_tool/trainer/ppo/ray_trainer.py
+++ b/verl_tool/trainer/ppo/ray_trainer.py
@@ -171,6 +171,7 @@ class AgentRayPPOTrainer(RayPPOTrainer):
                 "pad_token_id": self.tokenizer.pad_token_id,
                 "recompute_log_prob": False,
                 "do_sample": self.config.actor_rollout_ref.rollout.val_kwargs.do_sample,
+                "is_repeated_by_n", True,
                 "validate": True,
             }
             print(f"test_gen_batch meta info: {test_gen_batch.meta_info}")


### PR DESCRIPTION
Setting `val_kwargs.do_sample=True` causes a size mismatch error in the union of tensors, regardless of the value of `val_kwargs.n`. 

Example error:
```
Traceback (most recent call last):
  File "/code/verl-tool/verl_tool/trainer/main_ppo.py", line 27, in main
    run_ppo(config)
  File "/code/verl-tool/verl_tool/trainer/main_ppo.py", line 46, in run_ppo
    ray.get(runner.run.remote(config))
  File "/code/verl-tool/.venv/lib/python3.10/site-packages/ray/_private/auto_init_hook.py", line 22, in auto_init_wrapper
    return fn(*args, **kwargs)
  File "/code/verl-tool/.venv/lib/python3.10/site-packages/ray/_private/client_mode_hook.py", line 104, in wrapper
    return func(*args, **kwargs)
  File "/code/verl-tool/.venv/lib/python3.10/site-packages/ray/_private/worker.py", line 2849, in get
    values, debugger_breakpoint = worker.get_objects(object_refs, timeout=timeout)
  File "/code/verl-tool/.venv/lib/python3.10/site-packages/ray/_private/worker.py", line 937, in get_objects
    raise value.as_instanceof_cause()
ray.exceptions.RayTaskError(AssertionError): ray::TaskRunner.run() (pid=63180, ip=172.17.0.2, actor_id=3696fa7e5f8f24070fdfb7ab01000000, repr=<main_ppo.TaskRunner object at 0x7411dcebf100>)
  File "/code/verl-tool/verl_tool/trainer/main_ppo.py", line 185, in run
    trainer.fit()
  File "/code/verl-tool/verl_tool/trainer/ppo/ray_trainer.py", line 585, in fit
    val_metrics: dict = self._validate()
  File "/code/verl-tool/verl_tool/trainer/ppo/ray_trainer.py", line 196, in _validate
    test_batch = test_batch.union(test_output_gen_batch)
  File "/code/verl-tool/verl/verl/protocol.py", line 589, in union
    self.batch = union_tensor_dict(self.batch, other.batch)
  File "/code/verl-tool/verl/verl/protocol.py", line 107, in union_tensor_dict

    assert tensor_dict1.batch_size == tensor_dict2.batch_size, f"Two tensor dict must have identical batch size. Got {tensor_dict1.batch_size} and {tensor_dict2.batch_size}"
AssertionError: Two tensor dict must have identical batch size. Got torch.Size([64]) and torch.Size([256])
```

This case happens even when `val_kwargs.n=1`. Likely not observed before because Verl-tool was only tested with greedy validation.

This appears to be caused by a missing `"is_repeated_by_n":true` item in the `test_gen_batch.meta_info` object.  Adding this item results in no crashes and apparently correct parsing of the metrics info dict e.g. mean@n. There is a check for this item in manager.py:

https://github.com/TIGER-AI-Lab/verl-tool/blob/0f5ff2259666d16426e70dc992a9c7aee4f147e9/verl_tool/llm_agent/manager.py#L123