### PR TITLE
Add buffered code execution for early termination

### DIFF
--- a/verl_tool/servers/tests/test_python_code_tool.py
+++ b/verl_tool/servers/tests/test_python_code_tool.py
@@ -46,6 +46,11 @@ def test_python(
     print("--- Testing 8 ---") # memory limit
     action = """```<python>\nimport numpy as np\nx = np.random.rand(40000, 40000)\nsize_of_x_in_bytes = x.nbytes\nprint(f'Memory test completed after allocating a {len(x)}x{len(x[0])} array, which is {size_of_x_in_bytes / (1024 * 1024):.2f} MB.')</python> ...```"""
     print(_send_test_request(url, trajectory_id, action, "Python Memory Test"))
+
+    print("--- Testing 9 ---") # max buffer limit
+    action = """```<python>print("x"*68*1024)</python> ...```"""
+    _send_test_request(url, trajectory_id, action, "Python max buffer Test")
+
     return True
     
     
@@ -70,7 +75,11 @@ def _send_test_request(url, trajectory_id, action, test_name):
         # Print observation
         if "observations" in result and len(result["observations"]) > 0:
             observation = result["observations"][0]
-            logger.info(f"\n--- {test_name} Result ---\n{observation}\n")
+
+            if len(observation) < 1024*4:
+                logger.info(f"\n--- {test_name} Result ---\n{observation}\n")
+            else:
+                logger.info(f"\n--- {test_name} Result ---\nVERY LONG OUTPUT OMITTED: {len(observation)}\n")
         else:
             logger.error(f"No observation found in response for {test_name}")
         

--- a/verl_tool/servers/tools/python_code.py
+++ b/verl_tool/servers/tools/python_code.py
@@ -62,12 +62,10 @@ def process_output(proc, timeout, max_buffer):
                     stderr_eof = True  # EOF reached
 
             if len(stdout_buf) + len(stderr_buf) >= max_buffer:
-                print("Buffer limit exceeded.")
                 proc.kill()
                 break
 
             if timeout >= 0 and elapsed > timeout:
-                print("Timeout exceeded.")
                 proc.kill()
                 break
 

--- a/verl_tool/servers/tools/python_code.py
+++ b/verl_tool/servers/tools/python_code.py
@@ -298,16 +298,6 @@ def execute_python(code: Union[str, List[str]], timeout: int=TIMEOUT, stdin: Opt
 
     has_error = False
     try:
-        # result = subprocess.run(
-        #     command,
-        #     input=stdin if stdin else None,
-        #     env=env,
-        #     text=True,
-        #     capture_output=True,
-        #     preexec_fn=set_limits,
-        #     timeout=timeout,
-        #     cwd=subprocess_cwd,
-        # )
         proc = subprocess.Popen(
             command,
             stdout=subprocess.PIPE,


### PR DESCRIPTION
This replaces the python_code tool server execution logic to use a buffered iteration that jointly checks for time and length cutoffs, after each 1024 byte read operation. This includes a test which checks that MAX_BUFFER is active. Timeout behavior still behaves as expected. MAX_BUFFER is arbitrarily set as a global var to 1024*64 bytes, mainly to prevent excessive execution time and memory errors.

The additional test requests more than the limit:
```
    print("--- Testing 9 ---") # max buffer limit
    action = """```<python>print("x"*68*1024)</python> ...```"""
    _send_test_request(url, trajectory_id, action, "Python max buffer Test")
```

and shows that the length does not increase after the last passing 1024 block is read

The full test output now looks like this:
```
2025-07-28 23:48:08,899 - INFO - Testing Python code execution...
2025-07-28 23:48:09,064 - INFO - Response received for Python test
2025-07-28 23:48:09,064 - INFO - 
--- Python Result ---

<output>
Hello from Python!
</output>


2025-07-28 23:48:09,065 - INFO - Testing Python code execution...
2025-07-28 23:48:09,228 - INFO - Response received for Python test
2025-07-28 23:48:09,228 - INFO - 
--- Python Result ---

<output>
Hello from Python!
Arguments: []
Number 0
Number 1
Number 2
Number 3
Number 4
</output>


2025-07-28 23:48:09,229 - INFO - Testing Python code execution...
2025-07-28 23:48:09,290 - INFO - Response received for Python test
2025-07-28 23:48:09,291 - INFO - 
--- Python Result ---

```output
Hello from Python!
```


2025-07-28 23:48:09,291 - INFO - Testing Python code execution...
2025-07-28 23:48:09,452 - INFO - Response received for Python test
2025-07-28 23:48:09,452 - INFO - 
--- Python Result ---

<output>
Hello from Python!
Hello again!
</output>


2025-07-28 23:48:09,453 - INFO - Testing Python code execution...
2025-07-28 23:48:19,587 - INFO - Response received for Python test
2025-07-28 23:48:19,587 - INFO - 
--- Python Result ---

<output>

</output>


2025-07-28 23:48:19,588 - INFO - Testing Python code execution...
2025-07-28 23:48:19,657 - INFO - Response received for Python test
2025-07-28 23:48:19,658 - INFO - 
--- Python Result ---

<output>
Traceback (most recent call last):
  File "main.py", line 46, in <module>
    prnit('Hello from Python!')
NameError: name 'prnit' is not defined. Did you mean: 'print'?
</output>


2025-07-28 23:48:19,658 - INFO - Testing Python Memory Test code execution...
2025-07-28 23:48:20,282 - INFO - Response received for Python Memory Test test
2025-07-28 23:48:20,282 - INFO - 
--- Python Memory Test Result ---

<output>
Memory test completed after allocating a 5000x5000 array, which is 190.73 MB.
</output>


2025-07-28 23:48:20,283 - INFO - Testing Python Memory Test code execution...
2025-07-28 23:48:20,621 - INFO - Response received for Python Memory Test test
2025-07-28 23:48:20,622 - INFO - 
--- Python Memory Test Result ---

<output>
Traceback (most recent call last):
  File "main.py", line 47, in <module>
    x = np.random.rand(40000, 40000)
  File "numpy/random/mtrand.pyx", line 1219, in numpy.random.mtrand.RandomState.rand
  File "numpy/random/mtrand.pyx", line 437, in numpy.random.mtrand.RandomState.random_sample
  File "_common.pyx", line 307, in numpy.random._common.double_fill
numpy.core._exceptions._ArrayMemoryError: Unable to allocate 11.9 GiB for an array with shape (40000, 40000) and data type float64
</output>


2025-07-28 23:48:20,622 - INFO - Testing Python max buffer Test code execution...
2025-07-28 23:48:20,684 - INFO - Response received for Python max buffer Test test
2025-07-28 23:48:20,684 - INFO - 
--- Python max buffer Test Result ---
VERY LONG OUTPUT OMITTED: 65557

--- Testing 1 ---
{'observations': ['\n<output>\nHello from Python!\n</output>\n'], 'dones': [False], 'valids': [True]}
--- Testing 2 ---
{'observations': ['\n<output>\nHello from Python!\nArguments: []\nNumber 0\nNumber 1\nNumber 2\nNumber 3\nNumber 4\n</output>\n'], 'dones': [False], 'valids': [True]}
--- Testing 3 ---
{'observations': ['\n```output\nHello from Python!\n```\n'], 'dones': [False], 'valids': [True]}
--- Testing 4 ---
{'observations': ['\n<output>\nHello from Python!\nHello again!\n</output>\n'], 'dones': [False], 'valids': [True]}
--- Testing 5 ---
{'observations': ['\n<output>\n\n</output>\n'], 'dones': [False], 'valids': [True]}
--- Testing 6 ---
{'observations': ['\n<output>\nTraceback (most recent call last):\n  File "main.py", line 46, in <module>\n    prnit(\'Hello from Python!\')\nNameError: name \'prnit\' is not defined. Did you mean: \'print\'?\n</output>\n'], 'dones': [False], 'valids': [True]}
--- Testing 7 ---
{'observations': ['\n<output>\nMemory test completed after allocating a 5000x5000 array, which is 190.73 MB.\n</output>\n'], 'dones': [False], 'valids': [True]}
--- Testing 8 ---
{'observations': ['\n<output>\nTraceback (most recent call last):\n  File "main.py", line 47, in <module>\n    x = np.random.rand(40000, 40000)\n  File "numpy/random/mtrand.pyx", line 1219, in numpy.random.mtrand.RandomState.rand\n  File "numpy/random/mtrand.pyx", line 437, in numpy.random.mtrand.RandomState.random_sample\n  File "_common.pyx", line 307, in numpy.random._common.double_fill\nnumpy.core._exceptions._ArrayMemoryError: Unable to allocate 11.9 GiB for an array with shape (40000, 40000) and data type float64\n</output>\n'], 'dones': [False], 'valids': [True]}
--- Testing 9 ---
True
```

Let me know if any of the other tests are experiencing a regression