### PR TITLE
Support audio modality for qwen2.5-omni

### DIFF
--- a/examples/data_preprocess/mmau_pro/compute_sequence_length.py
+++ b/examples/data_preprocess/mmau_pro/compute_sequence_length.py
@@ -1,0 +1,312 @@
+"""
+Analyze input sequence length statistics for train and test datasets.
+Uses Qwen2_5OmniProcessor to process multimodal inputs and calculate sequence length statistics.
+"""
+
+import re
+import numpy as np
+import pandas as pd
+from transformers import Qwen2_5OmniProcessor
+import fire
+from tqdm import tqdm
+from concurrent.futures import ThreadPoolExecutor, as_completed
+
+
+def _build_messages(sample):
+    """
+    Build messages from sample following the same logic as rl_dataset.py _build_messages.
+    Converts content strings with <audio> tokens to structured format.
+    
+    Args:
+        sample: Sample dict with 'prompt' and 'audios' fields
+        
+    Returns:
+        list: Processed messages with structured content
+    """
+    # Extract messages from prompt (make a copy to avoid modifying original)
+    messages = [msg.copy() for msg in sample['prompt']]
+    
+    # If there are audios, process messages to convert <audio> tokens to structured format
+    if 'audios' in sample and sample.get('audios') is not None:
+        for message in messages:
+            content = message["content"]
+            # Only process string content (not already structured)
+            if isinstance(content, str):
+                content_list = []
+                # Split content by special tokens (<image>, <video>, <audio>)
+                segments = re.split("(<image>|<video>|<audio>)", content)
+                segments = [item for item in segments if item != ""]
+                for segment in segments:
+                    if segment == "<image>":
+                        content_list.append({"type": "image"})
+                    elif segment == "<video>":
+                        content_list.append({"type": "video"})
+                    elif segment == "<audio>":
+                        content_list.append({"type": "audio"})
+                    else:
+                        content_list.append({"type": "text", "text": segment})
+                
+                message["content"] = content_list
+    
+    return messages
+
+
+def process_sample(processor, sample, audio_start_special_token_id, audio_end_special_token_id):
+    """
+    Process a single sample with Qwen2_5OmniProcessor and return sequence length.
+    Follows the pattern from rl_dataset.py doc2len function.
+    
+    Args:
+        processor: Qwen2_5OmniProcessor instance
+        sample: Sample dict with 'prompt' and 'audios' fields
+        
+    Returns:
+        int: Sequence length (input_ids length), or None if processing fails
+    """
+    try:
+        # Build messages using the same logic as rl_dataset._build_messages
+        # This converts <audio> tokens in content strings to structured format
+        messages = _build_messages(sample)
+        
+        # Apply chat template to get raw prompt text
+        raw_prompt = processor.apply_chat_template(
+            messages, add_generation_prompt=True, tokenize=False
+        )
+        if isinstance(raw_prompt, list):
+            raw_prompt = raw_prompt[0]
+        
+        # Process audio files using process_audio from audio_utils
+        # This converts audio paths to numpy arrays that the processor expects
+        from verl_tool.utils.dataset.audio_utils import process_audio
+        
+        audios = None
+        if 'audios' in sample and sample.get('audios') is not None:
+            audios = [process_audio(audio) for audio in sample['audios']]
+        
+        # Process with Qwen2_5OmniProcessor
+        # Pass text as a list (processor expects list format)
+        inputs = processor(text=[raw_prompt], audio=audios)
+        
+        # Extract sequence length from input_ids
+        input_ids = inputs["input_ids"][0]
+        total_length = len(input_ids)
+        # keep audio sequence length calculation for future analysis
+        # audio_start_pos = np.where(input_ids == audio_start_special_token_id)[0]
+        # audio_end_pos = np.where(input_ids == audio_end_special_token_id)[0]
+        # audio_length = audio_end_pos - audio_start_pos + 1 
+
+        return total_length
+        
+    except Exception as e:
+        print(f"Warning: Failed to process sample: {e}")
+        return None
+
+def calculate_statistics(sequence_lengths):
+    """
+    Calculate statistics for sequence lengths.
+    
+    Args:
+        sequence_lengths: List of sequence lengths
+        
+    Returns:
+        dict: Statistics including min, max, q1, q2 (median), q3, and mean
+    """
+    if not sequence_lengths:
+        return None
+    
+    arr = np.array(sequence_lengths)
+    stats = {
+        'min': int(np.min(arr)),
+        'max': int(np.max(arr)),
+        'q1': int(np.percentile(arr, 25)),
+        'q2': int(np.percentile(arr, 50)),  # median
+        'q3': int(np.percentile(arr, 75)),
+        'mean': float(np.mean(arr)),
+        'std': float(np.std(arr)),
+        'count': len(sequence_lengths)
+    }
+    return stats
+
+
+def process_samples_parallel(
+    samples, processor, model_name, audio_start_special_token_id, 
+    audio_end_special_token_id, max_workers=16, desc="Processing"
+):
+    """
+    Process samples in parallel using ThreadPoolExecutor.
+    
+    Args:
+        samples: List of samples to process
+        processor: Qwen2_5OmniProcessor instance (shared across threads - thread-safe for read ops)
+        model_name: Model name (kept for compatibility, not used)
+        audio_start_special_token_id: Audio start token ID
+        audio_end_special_token_id: Audio end token ID
+        max_workers: Maximum number of worker threads
+        desc: Description for progress bar
+        
+    Returns:
+        list: List of sequence lengths in the same order as input samples (None for failed samples)
+    """
+    def process_single_sample(sample):
+        """Process a single sample using shared processor."""
+        return process_sample(
+            processor, sample, 
+            audio_start_special_token_id, audio_end_special_token_id
+        )
+    
+    # Process samples in parallel
+    # Note: transformers processors are thread-safe for read operations (tokenization, processing)
+    sequence_lengths = [None] * len(samples)  # Pre-allocate list to maintain order
+    
+    with ThreadPoolExecutor(max_workers=max_workers) as executor:
+        # Submit all tasks with their indices to maintain order
+        future_to_index = {
+            executor.submit(process_single_sample, sample): idx 
+            for idx, sample in enumerate(samples)
+        }
+        
+        # Collect results with progress bar
+        for future in tqdm(as_completed(future_to_index), total=len(samples), desc=desc):
+            idx = future_to_index[future]
+            seq_len = future.result()
+            sequence_lengths[idx] = seq_len
+    
+    return sequence_lengths
+
+
+def main(
+    train_parquet_path='/data/zhenxiong/data/mmau_pro/train.parquet',
+    test_parquet_path='/data/zhenxiong/data/mmau_pro/test.parquet',
+    model_name='qwen/qwen2.5-omni-3b',
+    max_samples=None,  # Limit number of samples for faster analysis (None = all)
+    max_workers=32,  # Maximum number of worker threads
+):
+    """
+    Analyze sequence lengths for train and test datasets.
+    
+    Args:
+        train_parquet_path: Path to train.parquet file
+        test_parquet_path: Path to test.parquet file
+        model_name: HuggingFace model name for Qwen2_5OmniProcessor
+        max_samples: Maximum number of samples to process (None for all)
+        max_workers: Maximum number of worker threads for parallel processing (default: 16)
+    """
+    print(f"Loading Qwen2_5OmniProcessor from {model_name}...", flush=True)
+    processor = Qwen2_5OmniProcessor.from_pretrained(model_name)
+
+    audio_start_special_token_id = processor.tokenizer.encode("<|audio_bos|>")[0]
+    audio_special_token_id = processor.tokenizer.encode("<|AUDIO|>")[0]
+    audio_end_special_token_id = processor.tokenizer.encode("<|audio_eos|>")[0]
+    print(audio_start_special_token_id, audio_special_token_id, audio_end_special_token_id)
+    
+    # Process train dataset
+    print(f"\nLoading train dataset from {train_parquet_path}...", flush=True)
+    train_df = pd.read_parquet(train_parquet_path)
+    train_samples = train_df.to_dict('records')
+    
+    if max_samples is not None:
+        train_samples = train_samples[:max_samples]
+    
+    print(f"Processing {len(train_samples)} train samples with {max_workers} workers...", flush=True)
+    train_sequence_lengths = process_samples_parallel(
+        train_samples, processor, model_name, 
+        audio_start_special_token_id, audio_end_special_token_id,
+        max_workers=max_workers, desc="Train"
+    )
+    
+    # Add seq_length column to train dataframe
+    train_df_with_seq = train_df.copy()
+    # Initialize seq_length column with None if it doesn't exist
+    if 'seq_length' not in train_df_with_seq.columns:
+        train_df_with_seq['seq_length'] = None
+    
+    if max_samples is not None:
+        # Only update the processed samples (use iloc for position-based indexing)
+        train_df_with_seq.iloc[:max_samples, train_df_with_seq.columns.get_loc('seq_length')] = train_sequence_lengths
+    else:
+        # Update all samples
+        train_df_with_seq['seq_length'] = train_sequence_lengths
+    # Filter out None values for statistics
+    train_sequence_lengths_filtered = [x for x in train_sequence_lengths if x is not None]
+    
+    # Process test dataset
+    print(f"\nLoading test dataset from {test_parquet_path}...", flush=True)
+    test_df = pd.read_parquet(test_parquet_path)
+    test_samples = test_df.to_dict('records')
+    
+    if max_samples is not None:
+        test_samples = test_samples[:max_samples]
+    
+    print(f"Processing {len(test_samples)} test samples with {max_workers} workers...", flush=True)
+    test_sequence_lengths = process_samples_parallel(
+        test_samples, processor, model_name,
+        audio_start_special_token_id, audio_end_special_token_id,
+        max_workers=max_workers, desc="Test"
+    )
+    
+    # Add seq_length column to test dataframe
+    test_df_with_seq = test_df.copy()
+    # Initialize seq_length column with None if it doesn't exist
+    if 'seq_length' not in test_df_with_seq.columns:
+        test_df_with_seq['seq_length'] = None
+    
+    if max_samples is not None:
+        # Only update the processed samples (use iloc for position-based indexing)
+        test_df_with_seq.iloc[:max_samples, test_df_with_seq.columns.get_loc('seq_length')] = test_sequence_lengths
+    else:
+        # Update all samples
+        test_df_with_seq['seq_length'] = test_sequence_lengths
+    # Filter out None values for statistics
+    test_sequence_lengths_filtered = [x for x in test_sequence_lengths if x is not None]
+    
+    # Write updated dataframes back to parquet files
+    train_df_with_seq.to_parquet("/data/zhenxiong/data/mmau_pro/train_w_length.parquet", index=False)
+    processed_count = len([x for x in train_sequence_lengths if x is not None])
+    print(f"Train dataset updated with seq_length column. Total samples: {len(train_df_with_seq)}, "
+          f"Processed: {processed_count}")
+    
+    test_df_with_seq.to_parquet("/data/zhenxiong/data/mmau_pro/test_w_length.parquet", index=False)
+    processed_count = len([x for x in test_sequence_lengths if x is not None])
+    print(f"Test dataset updated with seq_length column. Total samples: {len(test_df_with_seq)}, "
+          f"Processed: {processed_count}")
+    
+    # Calculate and print statistics
+    print("\n" + "="*60)
+    print("SEQUENCE LENGTH STATISTICS")
+    print("="*60)
+    
+    train_stats = calculate_statistics(train_sequence_lengths_filtered)
+    if train_stats:
+        print("\nTrain Dataset:")
+        print(f"  Count:    {train_stats['count']}")
+        print(f"  Min:      {train_stats['min']}")
+        print(f"  Q1:       {train_stats['q1']}")
+        print(f"  Q2 (Med): {train_stats['q2']}")
+        print(f"  Q3:       {train_stats['q3']}")
+        print(f"  Max:      {train_stats['max']}")
+        print(f"  Mean:     {train_stats['mean']:.2f}")
+        print(f"  Std:      {train_stats['std']:.2f}")
+        failed_count = len(train_sequence_lengths) - train_stats['count']
+        if failed_count > 0:
+            print(f"  Failed:   {failed_count} samples could not be processed")
+    
+    test_stats = calculate_statistics(test_sequence_lengths_filtered)
+    if test_stats:
+        print("\nTest Dataset:")
+        print(f"  Count:    {test_stats['count']}")
+        print(f"  Min:      {test_stats['min']}")
+        print(f"  Q1:       {test_stats['q1']}")
+        print(f"  Q2 (Med): {test_stats['q2']}")
+        print(f"  Q3:       {test_stats['q3']}")
+        print(f"  Max:      {test_stats['max']}")
+        print(f"  Mean:     {test_stats['mean']:.2f}")
+        print(f"  Std:      {test_stats['std']:.2f}")
+        failed_count = len(test_sequence_lengths) - test_stats['count']
+        if failed_count > 0:
+            print(f"  Failed:   {failed_count} samples could not be processed")
+    
+    print("\n" + "="*60)
+
+
+if __name__ == '__main__':
+    fire.Fire(main)

--- a/examples/data_preprocess/mmau_pro/filter_out_long_prompt.py
+++ b/examples/data_preprocess/mmau_pro/filter_out_long_prompt.py
@@ -1,0 +1,15 @@
+import pandas as pd
+
+max_seq_length = 8192 # threshold
+
+processed_train_path = "/data/zhenxiong/data/mmau_pro/train_w_length.parquet"
+processed_test_path = "/data/zhenxiong/data/mmau_pro/test_w_length.parquet"
+
+train_df = pd.read_parquet(processed_train_path)
+test_df = pd.read_parquet(processed_test_path)
+
+train_df = train_df[train_df['seq_length'] < max_seq_length]
+test_df = test_df[test_df['seq_length'] < max_seq_length]
+
+train_df.to_parquet("/data/zhenxiong/data/mmau_pro/train_w_length_filtered.parquet", index=False)
+test_df.to_parquet("/data/zhenxiong/data/mmau_pro/test_w_length_filtered.parquet", index=False)

--- a/examples/data_preprocess/mmau_pro/mmau_pro.py
+++ b/examples/data_preprocess/mmau_pro/mmau_pro.py
@@ -1,0 +1,145 @@
+"""
+Preprocess the MMAU-Pro dataset to parquet format
+"""
+
+import os
+
+import datasets
+import fire
+from pathlib import Path
+
+from verl.utils.hdfs_io import copy, makedirs
+
+# -------------------
+# prompts
+
+system_prompt = """You are a helpful audio & language assistant with external tools.
+
+You have access to the following tool(s) for audio(s) analysis:
+- Tool #1:
+{"type": "function", "function": {"name": "audio_crop", "description": "Crop the specified audio based on the time window in seconds.", "parameters": {"type": "object", "properties": {"time_window": {"type": "array", "description": "A tuple of two numbers indicating the start and end time (in seconds) of the audio segment to crop.", "items": {"type": "number"}}, "target_audio": {"type": "number", "description": "The index of the audio to crop. Index from 1 to the number of audios. Choose 1 to operate on original audio."}}, "required": ["time_window", "target_audio"]}}}
+
+To invoke a tool, please use the following format (ensure to use proper JSON formatting and you have to put it between <tool_call> and </tool_call>):
+<tool_call>
+{"name": "audio_crop", "arguments": {"time_window": [start_seconds, end_seconds], "target_audio": audio_index}}
+</tool_call>
+
+Now, you are connected with the user."""
+
+guideline = """
+RESPONSE GUIDELINE:
+1. [Given the audio, question and possible choices, expand on your reasoning step by step.]
+2. [Use tools, with correct tool-call format, to help you better understand the audios.]
+3. [Put your final answer in \boxed{exact_answer_text}]"""
+# -------------------
+
+def concat_question_and_choices(question:str, choices:list):
+    """
+    Concatenate the question with possible choices.
+    Args:
+        question (str): The question to concatenate.
+        choices (list): The choices to concatenate.
+    Returns:
+        str: The concatenated complete question with possible choices.
+    """
+    if choices is None or len(choices) == 0:
+        # if there are no choices available, we assume the question itself is complete
+        return question
+    return "Given the audio(s) information, answer the following question:\n<question>" \
+        + question \
+        + '\n</question>\nPossible choices:\n<choices>' \
+        + '\n'.join(choices) \
+        + "\n</choices>"
+
+
+def main(
+    data_source="gamma-lab-umd/MMAU-Pro", # the repo_id on huggingface dataset, https://huggingface.co/datasets/gamma-lab-umd/MMAU-Pro
+    local_dir='/data/zhenxiong/data/mmau_pro',
+    audio_dir="/data/zhenxiong/data/mmau_pro/audio",
+    hdfs_dir=None,
+    audio_sep="<audio>",
+):
+    
+    print(f"Loading the {data_source} dataset from huggingface...", flush=True)
+    dataset = datasets.load_dataset(data_source, cache_dir="/data/zhenxiong/hf_cache/", token=HF_TOKEN)["test"]
+    num_samples = len(dataset)
+    dataset = dataset.train_test_split(test_size=int(num_samples * 0.1), seed=42)
+    train_dataset = dataset['train']
+    test_dataset = dataset['test']
+    tiny_dataset = train_dataset.select(range(10)) # randomly select 10 samples from training set for debugging
+    
+    # add a row to each data item that represents a unique id
+    def make_train_map_fn(split, data_source):
+
+        def process_fn(example, idx):
+            question_raw = example.pop('question')
+            choices = example.pop('choices')
+            question_raw = concat_question_and_choices(question_raw, choices)
+            # Add guideline to the question
+            question_raw += f"\n\n{guideline}"
+            
+            answer = example.pop('answer')
+            category = example.pop('category')
+            audio_paths = [(Path(audio_dir) / audio_path.split("/")[-1]).absolute().as_posix() for audio_path in example.pop('audio_path')]
+            
+            # Build multimodal content with audio placeholder
+            mm_content = audio_sep * len(audio_paths) + question_raw
+            
+            # Build prompt following the format in prepare_train.py
+            prompt = [
+                {
+                    "role": "system",
+                    "content": system_prompt,
+                },
+                {
+                    "role": "user",
+                    "content": mm_content,
+                }
+            ]
+            
+            data = {
+                "data_source": data_source,
+                "prompt": prompt,
+                "audios": [{"audio": audio_path} for audio_path in audio_paths],
+                "ability": "audio_reasoning",
+                "reward_model": {
+                    "style": "rule",
+                    "ground_truth": answer
+                },
+                "extra_info": {
+                    'split': f"{split}_{idx}",
+                    'index': idx,
+                    'category': category,
+                    'audios': [{"audio": audio_path} for audio_path in audio_paths],
+                }
+            }
+            return data
+
+        return process_fn
+    
+    train_dataset = train_dataset.map(function=make_train_map_fn('train', data_source), with_indices=True, remove_columns=train_dataset.column_names)
+    test_dataset = test_dataset.map(function=make_train_map_fn('test', data_source), with_indices=True, remove_columns=test_dataset.column_names)
+    tiny_dataset = tiny_dataset.map(function=make_train_map_fn('tiny', data_source), with_indices=True, remove_columns=tiny_dataset.column_names)
+
+    print(f"Loaded {len(train_dataset)} training samples")
+    print(f"Loaded {len(test_dataset)} test samples")
+    print(f"Loaded {len(tiny_dataset)} tiny samples")
+    print("Example of a training sample:")
+    print(train_dataset[0])
+    
+    train_dataset.to_parquet(os.path.join(local_dir, 'train.parquet'))
+    test_dataset.to_parquet(os.path.join(local_dir, 'test.parquet'))
+    tiny_dataset.to_parquet(os.path.join(local_dir, 'tiny.parquet'))
+    print(f"Saved {len(train_dataset)} training samples to {local_dir}/train.parquet")
+    print(f"Saved {len(test_dataset)} test samples to {local_dir}/test.parquet")
+    print(f"Saved {len(tiny_dataset)} tiny samples to {local_dir}/tiny.parquet")
+
+    
+    if hdfs_dir is not None:
+        makedirs(hdfs_dir)
+
+        copy(src=local_dir, dst=hdfs_dir)
+    
+
+if __name__ == '__main__':
+    fire.Fire(main)

--- a/examples/train/mmau_pro/train_omni_4ranks.sh
+++ b/examples/train/mmau_pro/train_omni_4ranks.sh
@@ -1,0 +1,180 @@
+#!/bin/bash
+
+set -x
+dataset_name=mmau_pro
+dataset_root=..
+train_data=[${dataset_root}/data/${dataset_name}/train_w_length_filtered.parquet]
+val_data=[${dataset_root}/data/${dataset_name}/test_w_length_filtered.parquet]
+
+model_name=qwen/qwen2.5-omni-3b
+RAY_LOG_TO_DRIVER=1
+RAY_DEBUG_POST_MORTEM=1
+VERL_LOGGING_LEVEL=INFO
+
+rl_alg=grpo # gae(ppo) or grpo, if grpo, then better set n>1 otherwise the group norm can not be effective
+
+n_nodes=1
+n_gpus_per_node=4
+fsdp_size=4
+
+# empirically, we want batch_size * n \approx 128 to get optimal performance
+batch_size=8
+n=8
+log_prob_micro_batch_size_per_gpu=8
+# mini_batch_size == batch_size means all updates are on-policy
+ppo_mini_batch_size=8 # actually, there are mini_batch_size * n traj are used for policy updates
+ppo_micro_batch_size_per_gpu=1 # update 1 traj per micro_batch to avoid oom
+
+tensor_model_parallel_size=2 # use two GPUs to load one model copy
+PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True
+
+max_prompt_length=8192 # should be big to avoid any truncation of audio tokens which will cause error
+max_response_length=8192
+max_action_length=512
+max_obs_length=8192 # should be big to avoid any truncation of audio tokens which will cause error
+max_turns=1
+ppo_max_token_len_per_gpu=$(expr $max_prompt_length + $max_response_length)
+
+rollout_max_num_seqs=64
+gpu_memory_utilization=0.6
+max_num_batched_tokens=512
+
+temperature=0.9
+top_p=1.0
+enable_agent=True # enable agent for tool use
+strategy="fsdp2"
+action_stop_tokens='</tool_call>'
+
+kl_loss_coef=0.0
+kl_coef=0
+entropy_coeff=0
+kl_loss_type=low_var_kl
+lr=1e-6
+
+reward_manager=audio
+
+do_offload=True # control actor's fsdp.[param|optimizer]_offload and actor_rollout_ref.rollout.fsdp.[param|optimizer]_offload; if gpu_memory_utilization is set to > 0.6, then do_offload should be set to True otherwise it will cause OOM
+
+use_dynamic_bsz=True # faster
+ulysses_sequence_parallel_size=1 # set to 1 for normal verl behavior, otherwise it will cause OOM
+additional_eos_token_ids=[151645] # <|im_end|> token id
+mask_observations=True # mask observations for kl loss and gradient descent
+enable_mtrl=True # enable multi-turn training
+
+model_pretty_name=$(echo $model_name | tr '/' '_' | tr '[:upper:]' '[:lower:]')
+run_name_postfix="debug-complex-reward"
+if [ "$enable_agent" = "True" ]; then
+    run_name="${reward_manager}-${strategy}-agent-${model_pretty_name}-${rl_alg}-n${n}-b${batch_size}-t${temperature}-lr${lr}${run_name_postfix}"
+else
+    run_name="${reward_manager}-${strategy}-${model_pretty_name}-${rl_alg}-n${n}-b${batch_size}-t${temperature}-lr${lr}${run_name_postfix}"
+fi
+export VERL_RUN_ID=$run_name
+export NCCL_DEBUG=INFO
+export VLLM_USE_V1=1
+export RAY_memory_usage_threshold=0.98
+export RAY_memory_monitor_refresh_ms=0  # Disable Ray memory monitor to prevent false OOM kills
+rollout_mode='async'
+
+# temp file for action tokens as verl cannot pass special strs as params
+action_stop_tokens_file="$(pwd)$(mktemp)"
+mkdir -p $(dirname $action_stop_tokens_file)
+echo -e -n "$action_stop_tokens" | tee $action_stop_tokens_file
+echo "action_stop_tokens_file=$action_stop_tokens_file"
+
+host=$(hostname -i | awk '{print $1}')
+port=$(shuf -i 30000-31000 -n 1)
+tool_server_url=http://$host:$port/get_observation
+python -m verl_tool.servers.serve --host $host --port $port --tool_type "audio_crop" --workers_per_tool 2 &
+server_pid=$!
+
+echo "Server (pid=$server_pid) started at $tool_server_url"
+
+PYTHONUNBUFFERED=1 python3 -m verl_tool.trainer.main_ppo \
+    algorithm.adv_estimator=$rl_alg \
+    data.train_files=$train_data \
+    data.val_files=$val_data \
+    data.dataloader_num_workers=1 \
+    data.train_batch_size=$batch_size \
+    data.val_batch_size=64 \
+    data.max_prompt_length=$max_prompt_length \
+    data.max_response_length=$max_response_length \
+    data.filter_overlong_prompts=False \
+    data.truncation='right' \
+    reward_model.reward_manager=$reward_manager \
+    reward_model.launch_reward_fn_async=True \
+    actor_rollout_ref.model.path=$model_name \
+    actor_rollout_ref.model.enable_gradient_checkpointing=True \
+    actor_rollout_ref.actor.optim.lr=$lr \
+    actor_rollout_ref.actor.optim.lr_warmup_steps=10 \
+    actor_rollout_ref.model.use_remove_padding=True \
+    actor_rollout_ref.model.trust_remote_code=True \
+    actor_rollout_ref.actor.checkpoint.save_contents=['model','optimizer','extra','hf_model'] \
+    actor_rollout_ref.actor.ppo_mini_batch_size=$ppo_mini_batch_size \
+    actor_rollout_ref.actor.ppo_micro_batch_size_per_gpu=$ppo_micro_batch_size_per_gpu \
+    actor_rollout_ref.actor.use_dynamic_bsz=$use_dynamic_bsz \
+    actor_rollout_ref.actor.ppo_max_token_len_per_gpu=$ppo_max_token_len_per_gpu \
+    actor_rollout_ref.actor.use_kl_loss=True \
+    actor_rollout_ref.actor.strategy=$strategy \
+    actor_rollout_ref.actor.kl_loss_coef=$kl_loss_coef \
+    actor_rollout_ref.actor.kl_loss_type=$kl_loss_type \
+    actor_rollout_ref.actor.entropy_coeff=$entropy_coeff \
+    actor_rollout_ref.actor.fsdp_config.param_offload=$do_offload \
+    actor_rollout_ref.actor.fsdp_config.optimizer_offload=$do_offload \
+    actor_rollout_ref.actor.fsdp_config.offload_policy=$do_offload \
+    actor_rollout_ref.actor.fsdp_config.fsdp_size=$fsdp_size \
+    actor_rollout_ref.actor.ulysses_sequence_parallel_size=$ulysses_sequence_parallel_size \
+    actor_rollout_ref.agent.enable_agent=$enable_agent \
+    actor_rollout_ref.agent.tool_server_url=$tool_server_url \
+    actor_rollout_ref.agent.max_prompt_length=$max_prompt_length \
+    actor_rollout_ref.agent.max_response_length=$max_response_length \
+    actor_rollout_ref.agent.max_start_length=$max_prompt_length \
+    actor_rollout_ref.agent.max_obs_length=$max_obs_length \
+    actor_rollout_ref.agent.max_turns=$max_turns \
+    actor_rollout_ref.agent.additional_eos_token_ids=$additional_eos_token_ids \
+    actor_rollout_ref.agent.mask_observations=$mask_observations \
+    actor_rollout_ref.agent.action_stop_tokens=$action_stop_tokens_file \
+    actor_rollout_ref.agent.enable_mtrl=$enable_mtrl \
+    actor_rollout_ref.agent.max_action_length=$max_action_length \
+    actor_rollout_ref.agent.max_concurrent_trajectories=64 \
+    actor_rollout_ref.rollout.tensor_model_parallel_size=$tensor_model_parallel_size \
+    actor_rollout_ref.rollout.log_prob_micro_batch_size_per_gpu=$log_prob_micro_batch_size_per_gpu \
+    actor_rollout_ref.rollout.enforce_eager=True \
+    actor_rollout_ref.rollout.free_cache_engine=True \
+    actor_rollout_ref.rollout.name=vllm \
+    actor_rollout_ref.rollout.gpu_memory_utilization=$gpu_memory_utilization \
+    actor_rollout_ref.rollout.temperature=$temperature \
+    actor_rollout_ref.rollout.top_p=$top_p \
+    actor_rollout_ref.rollout.top_k=-1 \
+    actor_rollout_ref.rollout.n=$n \
+    actor_rollout_ref.rollout.log_prob_use_dynamic_bsz=$use_dynamic_bsz \
+    actor_rollout_ref.rollout.max_num_seqs=$rollout_max_num_seqs \
+    actor_rollout_ref.rollout.mode=$rollout_mode \
+    actor_rollout_ref.rollout.max_num_batched_tokens=$max_num_batched_tokens \
+    actor_rollout_ref.ref.log_prob_use_dynamic_bsz=$use_dynamic_bsz \
+    actor_rollout_ref.ref.fsdp_config.param_offload=$do_offload \
+    actor_rollout_ref.ref.log_prob_micro_batch_size_per_gpu=$log_prob_micro_batch_size_per_gpu \
+    actor_rollout_ref.ref.ulysses_sequence_parallel_size=$ulysses_sequence_parallel_size \
+    critic.optim.lr=1e-5 \
+    critic.strategy=$strategy \
+    critic.model.path=$model_name \
+    critic.model.fsdp_config.offload_policy=True \
+    critic.model.fsdp_config.fsdp_size=$fsdp_size \
+    critic.ppo_micro_batch_size_per_gpu=$ppo_micro_batch_size_per_gpu \
+    critic.ulysses_sequence_parallel_size=$ulysses_sequence_parallel_size \
+    algorithm.kl_ctrl.kl_coef=$kl_coef \
+    trainer.logger=['console','wandb'] \
+    trainer.project_name=$reward_manager \
+    trainer.experiment_name=$run_name \
+    trainer.val_before_train=False \
+    trainer.default_hdfs_dir=null \
+    trainer.n_gpus_per_node=$n_gpus_per_node \
+    trainer.nnodes=$n_nodes \
+    trainer.save_freq=10 \
+    trainer.test_freq=10 \
+    trainer.total_epochs=10 \
+    trainer.total_training_steps=100 \
+    +trainer.rollout_data_dir=$(pwd)/verl_step_records/$run_name \
+    
+
+pkill -P -9 $server_pid
+kill -9 $server_pid

--- a/patches/qwen_2_5_omni.patch
+++ b/patches/qwen_2_5_omni.patch
@@ -1,0 +1,158 @@
+diff --git a/verl/models/transformers/monkey_patch.py b/verl/models/transformers/monkey_patch.py
+index 59b342f8..672d95fc 100644
+--- a/verl/models/transformers/monkey_patch.py
++++ b/verl/models/transformers/monkey_patch.py
+@@ -265,11 +265,17 @@ def apply_monkey_patch(
+     try:
+         num_attention_heads, num_key_value_heads = model.config.num_attention_heads, model.config.num_key_value_heads
+     except AttributeError:
+-        num_attention_heads, num_key_value_heads = (
+-            model.config.text_config.num_attention_heads,
+-            model.config.text_config.num_key_value_heads,
+-        )
+-
++        try:
++            num_attention_heads, num_key_value_heads = (
++                model.config.text_config.num_attention_heads,
++                model.config.text_config.num_key_value_heads,
++            )
++        except AttributeError:
++            num_attention_heads, num_key_value_heads = (
++                model.config.thinker_config.text_config.num_attention_heads,
++                model.config.thinker_config.text_config.num_key_value_heads,
++            )
++            
+     assert num_attention_heads % ulysses_sp_size == 0, (
+         f"num_attention_heads {num_attention_heads} must be divisible by ulysses_sp_size {ulysses_sp_size}"
+     )
+diff --git a/verl/utils/checkpoint/fsdp_checkpoint_manager.py b/verl/utils/checkpoint/fsdp_checkpoint_manager.py
+index 4b3d7a8e..f7d8ac35 100644
+--- a/verl/utils/checkpoint/fsdp_checkpoint_manager.py
++++ b/verl/utils/checkpoint/fsdp_checkpoint_manager.py
+@@ -316,10 +316,17 @@ class FSDPCheckpointManager(BaseCheckpointManager):
+                     from transformers import AutoModelForTokenClassification
+ 
+                     auto_model_cls = AutoModelForTokenClassification
++                    use_from_config = True
+                 elif "ForCausalLM" in model_config.architectures[0]:
+                     from transformers import AutoModelForCausalLM
+ 
+                     auto_model_cls = AutoModelForCausalLM
++                    use_from_config = True
++                elif "Qwen2_5OmniModel" in model_config.architectures[0]:
++                    from transformers import Qwen2_5OmniForConditionalGeneration
++
++                    auto_model_cls = Qwen2_5OmniForConditionalGeneration
++                    use_from_config = False  # Qwen2.5-Omni doesn't have from_config method
+                 elif "ForConditionalGeneration" in model_config.architectures[0]:
+                     # Handle different transformers versions for Vision2Seq models
+                     import transformers
+@@ -335,11 +342,17 @@ class FSDPCheckpointManager(BaseCheckpointManager):
+                         from transformers import AutoModelForVision2Seq
+ 
+                         auto_model_cls = AutoModelForVision2Seq
++                    use_from_config = True
+                 else:
+                     raise NotImplementedError(f"Unknown architecture {model_config['architectures']}")
+ 
+                 with init_empty_weights():
+-                    save_model = auto_model_cls.from_config(model_config, torch_dtype=torch.bfloat16)
++                    if use_from_config:
++                        save_model = auto_model_cls.from_config(model_config, torch_dtype=torch.bfloat16)
++                    else:
++                        # For models without from_config (e.g., Qwen2.5-Omni), instantiate directly
++                        # The dtype will be preserved from the state_dict when loading
++                        save_model = auto_model_cls(config=model_config)
+                 save_model.to_empty(device="cpu")
+ 
+                 if save_model.can_generate():
+diff --git a/verl/utils/dataset/rl_dataset.py b/verl/utils/dataset/rl_dataset.py
+index 870c4751..17bae6c6 100644
+--- a/verl/utils/dataset/rl_dataset.py
++++ b/verl/utils/dataset/rl_dataset.py
+@@ -105,6 +105,7 @@ class RLHFDataset(Dataset):
+         self.prompt_key = config.get("prompt_key", "prompt")
+         self.image_key = config.get("image_key", "images")
+         self.video_key = config.get("video_key", "videos")
++        self.audio_key = config.get("audio_key", "audios")
+         self.image_patch_size = config.get("image_patch_size", 14)
+         self.max_prompt_length = config.get("max_prompt_length", 1024)
+         self.return_raw_chat = config.get("return_raw_chat", False)
+@@ -269,17 +270,19 @@ class RLHFDataset(Dataset):
+     def _build_messages(self, example: dict):
+         messages: list = example.pop(self.prompt_key)
+ 
+-        if self.image_key in example or self.video_key in example:
++        if self.image_key in example or self.video_key in example or self.audio_key in example:
+             for message in messages:
+                 content = message["content"]
+                 content_list = []
+-                segments = re.split("(<image>|<video>)", content)
++                segments = re.split("(<image>|<video>|<audio>)", content)
+                 segments = [item for item in segments if item != ""]
+                 for segment in segments:
+                     if segment == "<image>":
+                         content_list.append({"type": "image"})
+                     elif segment == "<video>":
+                         content_list.append({"type": "video"})
++                    elif segment == "<audio>":
++                        content_list.append({"type": "audio"})
+                     else:
+                         content_list.append({"type": "text", "text": segment})
+ 
+@@ -297,10 +300,12 @@ class RLHFDataset(Dataset):
+ 
+         if self.processor is not None:
+             from verl.utils.dataset.vision_utils import process_image, process_video
+-
++            from verl_tool.utils.dataset.audio_utils import process_audio
+             raw_prompt = self.processor.apply_chat_template(
+                 messages, add_generation_prompt=True, tokenize=False, **self.apply_chat_template_kwargs
+             )
++            if isinstance(raw_prompt, list):
++                raw_prompt = raw_prompt[0]
+             multi_modal_data = {}
+ 
+             images = None
+@@ -312,6 +317,12 @@ class RLHFDataset(Dataset):
+                 # link: https://github.com/vllm-project/vllm/blob/3c545c0c3b98ee642373a308197d750d0e449403/vllm/multimodal/parse.py#L205
+                 multi_modal_data["image"] = images
+ 
++            audios = None
++            row_dict_audios = row_dict.pop(self.audio_key, None)
++            if row_dict_audios:
++                audios = [process_audio(audio) for audio in row_dict_audios]
++                multi_modal_data["audio"] = audios
++
+             videos = None
+             videos_kwargs = {}
+             row_dict_videos = row_dict.pop(self.video_key, None)
+@@ -334,7 +345,7 @@ class RLHFDataset(Dataset):
+                 ]
+ 
+             model_inputs = self.processor(
+-                text=[raw_prompt], images=images, videos=videos, videos_kwargs=videos_kwargs, return_tensors="pt"
++                text=[raw_prompt], audio=audios, images=images, videos=videos, videos_kwargs=videos_kwargs, return_tensors="pt"
+             )
+ 
+             input_ids = model_inputs.pop("input_ids")
+diff --git a/verl/workers/fsdp_workers.py b/verl/workers/fsdp_workers.py
+index a457925f..8f441447 100644
+--- a/verl/workers/fsdp_workers.py
++++ b/verl/workers/fsdp_workers.py
+@@ -371,6 +371,15 @@ class ActorRolloutRefWorker(Worker, DistProfilerExtension):
+                     actor_module_class = AutoModelForCausalLM
+                 elif type(actor_model_config) in AutoModelForImageTextToText._model_mapping.keys():
+                     actor_module_class = AutoModelForImageTextToText
++                elif getattr(actor_model_config, "architectures", None) == ["Qwen2_5OmniModel"]:
++                    # qwen2.5-omni is not supported by all previous AutoModels...
++                    from transformers import Qwen2_5OmniForConditionalGeneration
++                    # patch the Qwen2_5OmniForConditionalGeneration 
++                    # to use thinker as the forward function
++                    class Qwen2_5Omni(Qwen2_5OmniForConditionalGeneration):
++                        def forward(self, *args, **kwargs):
++                            return self.thinker(*args, **kwargs)
++                    actor_module_class = Qwen2_5Omni
+                 else:
+                     actor_module_class = AutoModel
+ 

--- a/verl_tool/agent_loop/agent_loop.py
+++ b/verl_tool/agent_loop/agent_loop.py
@@ -92,6 +92,7 @@ class AsyncLLMServerManager:
         prompt_ids: list[int],
         sampling_params: dict[str, Any],
         image_data: Optional[list[Any]] = None,
+        audio_data: Optional[list[Any]] = None,
     ) -> TokenOutput:
         """Generate tokens from prompt ids.
 
@@ -109,6 +110,7 @@ class AsyncLLMServerManager:
             prompt_ids=prompt_ids,
             sampling_params=sampling_params,
             image_data=image_data,
+            audio_data=audio_data,
         )
         return output
 
@@ -585,10 +587,27 @@ class AgentLoopWorker:
             input_ids = torch.cat([prompt_output["input_ids"], response_output["input_ids"]], dim=1)
 
             # Handle multi-modal inputs and position_ids calculation
-            # Only support Qwen2VLImageProcessor for multi-modal processing currently
+            # Only support Qwen2VLImageProcessor for multi-modal processing 
+            # and Qwen2_5OmniProcessor for audio processing currently
             # TODO: support other multi-modal inputs
             multi_modal_inputs = None
             if (
+                self.processor is not None 
+                and "Qwen2_5OmniProcessor" in self.processor.__class__.__name__
+            ):
+                audios = output.multi_modal_data.get("audio", None)
+                current_text = self.tokenizer.decode(input_ids.squeeze(0), skip_special_tokens=True)
+                processor_kwargs = {"text": [current_text], "return_tensors": "pt"}
+                if audios:
+                    processor_kwargs["audio"] = audios
+                multi_modal_inputs = self.processor(**processor_kwargs)
+                multi_modal_inputs.pop("input_ids", None)
+                multi_modal_inputs.pop("attention_mask", None)
+                # Convert to plain dict to keep tensor values when wrapped later
+                multi_modal_inputs = dict(multi_modal_inputs)
+                # Qwen2.5-Omni uses standard sequential position ids
+                position_ids = compute_position_id_with_mask(attention_mask)  # (1, seq_len)
+            elif (
                 self.processor is not None
                 and "Qwen2VLImageProcessor" in self.processor.image_processor.__class__.__name__
             ):
@@ -624,6 +643,7 @@ class AgentLoopWorker:
                 position_ids = torch.cat((text_position_ids, vision_position_ids), dim=1)  # (1, 4, seq_length)
             else:
                 position_ids = compute_position_id_with_mask(attention_mask)  # (1, seq_len)
+            
             enable_async_reward = (
                 self.rm_executor is not None and self.config.reward_model.enable_resource_pool
             ) or not self.config.reward_model.enable

--- a/verl_tool/agent_loop/verltool_agent_loop.py
+++ b/verl_tool/agent_loop/verltool_agent_loop.py
@@ -28,6 +28,7 @@ from uuid import uuid4
 from verl.utils.profiler import simple_timer
 from .agent_loop import AgentLoopBase, register, AgentLoopOutput
 from .vision_utils import decode_image_url, encode_image, encode_image_url
+from verl_tool.utils.dataset.audio_utils import encode_audio_data
 
 logger = logging.getLogger(__file__)
 logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "WARN"))
@@ -156,7 +157,16 @@ class VerlToolAgentLoop(AgentLoopBase):
             # for multimodal processing
             cls.qwen_image_placeholder = "<|vision_start|><|image_pad|><|vision_end|>"
             cls.qwen_video_placeholder = "<|vision_start|><|video_pad|><|vision_end|>"
-            cls.non_truncate_tokens = ["<|vision_start|>", "<|image_pad|>", "<|vision_end|>", "<|video_pad|>"]
+            cls.qwen_audio_placeholder = "<|audio_bos|><|AUDIO|><|audio_eos|>"  # for qwen2.5-omni
+            cls.non_truncate_tokens = [
+                "<|vision_start|>",
+                "<|image_pad|>",
+                "<|vision_end|>",
+                "<|video_pad|>",
+                "<|audio_bos|>",
+                "<|AUDIO|>",
+                "<|audio_eos|>",
+            ]
             cls.non_truncate_token_ids = [cls.tokenizer.convert_tokens_to_ids(tok) for tok in cls.non_truncate_tokens]
             
             
@@ -287,10 +297,13 @@ class VerlToolAgentLoop(AgentLoopBase):
         
     async def run(self, sampling_params: dict[str, Any], **kwargs) -> AgentLoopOutput:
         prompt_ids = list(kwargs["raw_prompt_ids"])
-        image_data = (kwargs.get("multi_modal_data") or {}).get("image", None)
+        multi_modal_data = kwargs.get("multi_modal_data") or {}
+        image_data = multi_modal_data.get("image")
         encoded_image_data = [encode_image_url(img) for img in image_data] if image_data is not None else None
+        audio_data = multi_modal_data.get("audio")
+        encoded_audio_data = [encode_audio_data(audio) for audio in audio_data] if audio_data is not None else None
         use_tool = kwargs.get("use_tool", self.agent_config.enable_agent)
-
+        
         metrics = {}
         request_id = str(uuid4().hex)
         
@@ -306,9 +319,14 @@ class VerlToolAgentLoop(AgentLoopBase):
             "is_traj_finished": False,
         }
         
-        if image_data:
+        if image_data or audio_data:
             raw_prompt_text = self.tokenizer.decode(prompt_ids, skip_special_tokens=False)
-            model_inputs = self.processor(text=[raw_prompt_text], images=image_data, return_tensors="pt")
+            processor_kwargs = {"text": [raw_prompt_text], "return_tensors": "pt"}
+            if image_data:
+                processor_kwargs["images"] = image_data
+            if audio_data:
+                processor_kwargs["audio"] = audio_data
+            model_inputs = self.processor(**processor_kwargs)
             prompt_ids = model_inputs["input_ids"].squeeze(0).tolist()
             
         max_response_length = self.agent_config.max_response_length
@@ -324,6 +342,7 @@ class VerlToolAgentLoop(AgentLoopBase):
         
         running_prompt_ids = prompt_ids.copy()
         running_image_data = image_data.copy() if image_data is not None else None
+        running_audio_data = audio_data.copy() if audio_data is not None else None
         response_mask = []
         response_logprobs = []
         traj_stop_reason = ""
@@ -340,7 +359,11 @@ class VerlToolAgentLoop(AgentLoopBase):
             # agent_sampling_params["max_new_tokens"] = max_tokens_for_this_turn # for sglang
             with simple_timer("generate_sequences", metrics):
                 output = await self.server_manager.generate(
-                    request_id=str(uuid4().hex), prompt_ids=running_prompt_ids, sampling_params=agent_sampling_params, image_data=running_image_data
+                    request_id=request_id,
+                    prompt_ids=running_prompt_ids,
+                    sampling_params=agent_sampling_params,
+                    image_data=running_image_data,
+                    audio_data=running_audio_data,
                 ) # request_id here should be unique for each generate call, otherwise vllm can generate empty response
                 if output.text.strip() == "":
                     logger.warning(f"Turn {step}: Generated empty response for traj_id={request_id}. prompt_ids length: {len(running_prompt_ids)}")
@@ -379,13 +402,18 @@ class VerlToolAgentLoop(AgentLoopBase):
                         break
             # send generated action to tool server
             if do_action and not is_last_step:
-                logger.debug(f"Turn {step}: finish_reason={finish_reason}, stop_reason={stop_reason}, do_action={do_action}, action_text={json.dumps(action_text[-50:])}")
+                extra_fields = {}
+                if encoded_image_data is not None:
+                    extra_fields["images"] = encoded_image_data
+                if encoded_audio_data is not None:
+                    extra_fields["audio"] = encoded_audio_data
+                logger.info(f"Turn {step}: finish_reason={finish_reason}, stop_reason={stop_reason}, do_action={do_action}, action_text={json.dumps(action_text[-50:])}")
                 with simple_timer("interact_with_tool_server", metrics):
                     tool_results = await self.interact_with_tool_server(
                         traj_id=request_id,
                         action=action_text,
                         do_action=do_action,
-                        extra_fields={"images": encoded_image_data} if encoded_image_data is not None else None,
+                        extra_fields=extra_fields,
                         is_last_step=is_last_step,
                     )
                 # process observations and prepare for next turn
@@ -404,6 +432,36 @@ class VerlToolAgentLoop(AgentLoopBase):
                     # now replace <image> tags with image placeholder tokens
                     obs_text = obs_text.replace("<image>", self.qwen_image_placeholder, num_image_tags)
                     obs_token_ids = self.processor(text=[obs_text], images=decoded_images, return_tensors="pt")["input_ids"].squeeze(0).tolist()
+                    if max_obs_length < len(obs_token_ids):
+                        if self.agent_config.truncate_obs_side == 'left':
+                            truncation_index = max_obs_length
+                            if obs_token_ids[max_obs_length] in self.non_truncate_token_ids:
+                                # find the nearest non-truncate token id before max_obs_length
+                                truncation_index = max_obs_length - 1
+                                while truncation_index > 0 and obs_token_ids[truncation_index] in self.non_truncate_token_ids:
+                                    truncation_index -= 1
+                            obs_token_ids = obs_token_ids[:truncation_index]
+                            obs_token_ids.extend(self.tokenizer.encode("...(truncated)"))
+                        else:
+                            raise NotImplementedError(f"Only left truncation is supported for multimodal observations for now.")
+                elif tool_results.get('audio', None):
+                    audios = [tool_results['audio']] if not isinstance(tool_results['audio'], list) else tool_results['audio']
+                    decoded_audios = [decode_image_url(audio_url) for audio_url in audios]
+                    running_audio_data.extend(decoded_audios)
+                    # add audio placeholder token ids
+                    # first see whether there are <audio> tags in obs_text
+                    num_audio_tags = obs_text.count("<audio>")
+                    if num_audio_tags < len(decoded_audios):
+                        # append at the end
+                        obs_text += "<audio>" * (len(decoded_audios) - num_audio_tags)
+                        num_audio_tags = len(decoded_audios)
+                    # now replace <audio> tags with audio placeholder tokens
+                    obs_text = obs_text.replace("<audio>", self.qwen_audio_placeholder, num_audio_tags)
+                    # for mtrl
+                    if self.enable_mtrl:
+                        obs_text = self.mtrl_sep.format(obs=obs_text)
+                    obs_token_ids = self.processor(text=[obs_text], audio=decoded_audios, return_tensors="pt")["input_ids"].squeeze(0).tolist()
+                    # obs_token_ids = obs_token_ids[:max_obs_length]
                     if max_obs_length < len(obs_token_ids):
                         if self.agent_config.truncate_obs_side == 'left':
                             truncation_index = max_obs_length
@@ -493,12 +551,18 @@ class VerlToolAgentLoop(AgentLoopBase):
             "is_traj_finished": float(stats_dict["is_traj_finished"]),
         })
         
+        multi_modal_output = {}
+        if running_image_data is not None:
+            multi_modal_output["image"] = running_image_data
+        if running_audio_data is not None:
+            multi_modal_output["audio"] = running_audio_data
+
         output = AgentLoopOutput(
             prompt_ids=prompt_ids,
             response_ids=response_ids[: self.response_length],
             response_mask=response_mask[: self.response_length],
             response_logprobs=response_logprobs[: self.response_length],
-            multi_modal_data={"image": running_image_data} if running_image_data is not None else {},
+            multi_modal_data=multi_modal_output,
             num_turns=stats_dict["num_turns"],
             metrics=metrics,
             extra_fields={"tool_interact_info": stats_dict.get("tool_interact_info", []), "traj_stop_reason": traj_stop_reason},

--- a/verl_tool/servers/tools/audio_crop.py
+++ b/verl_tool/servers/tools/audio_crop.py
@@ -1,0 +1,283 @@
+"""
+Audio crop tool for extracting segments from audio assets.
+This version is aligned with the I/O format of pixel_reasoner.py.
+"""
+import base64
+import json
+import math
+import uuid
+import io
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+import numpy as np
+import regex as re
+import soundfile as sf
+
+from .base import BaseTool, register_tool
+
+TIMEOUT = 20
+VALID_CALL_NAMES = {"audio_crop"}
+SAMPLE_RATE = 16000
+MIN_CROP_DURATION_SECONDS = 1.0
+
+AUDIO_CROP_FUNCTION_SPEC = {
+    "type": "function",
+    "function": {
+        "name": "audio_crop",
+        "description": "Crop the audio based on the time window.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "time_window": {
+                    "type": "array",
+                    "description": "A tuple of two numbers indicating the start and end time (in seconds) of the audio segment to crop.",
+                    "items": {"type": "number"},
+                },
+                "target_audio": {
+                    "type": "number",
+                    "description": "The index of the audio to crop. Index from 1 to the number of audios. Choose 1 to operate on original audio.",
+                },
+            },
+            "required": ["time_window", "target_audio"],
+        },
+    },
+}
+
+
+def _resolve_audio_source(audio_source: dict | str | Any) -> str:
+    """Returns a string audio location or data URI from various representations."""
+    if isinstance(audio_source, dict):
+        if "audio" in audio_source and isinstance(audio_source["audio"], str):
+            return audio_source["audio"]
+        if "audio_url" in audio_source and isinstance(audio_source["audio_url"], str):
+            return audio_source["audio_url"]
+        raise ValueError(f"Unsupported audio source dict structure: {audio_source.keys()}")
+    if isinstance(audio_source, str):
+        return audio_source
+    raise TypeError(f"Unsupported audio source type: {type(audio_source)}")
+
+
+def decode_audio_url(audio_source: str) -> Tuple[np.ndarray, int]:
+    """Decodes an audio source (path or data URI) into a numpy array."""
+    assert isinstance(audio_source, str), f"system error: audio_source must be a string, got {type(audio_source)}"
+    if audio_source.startswith("data:audio/"):
+        # It's a data URI
+        header, encoded = audio_source.split(",", 1)
+        audio_bytes = base64.b64decode(encoded)
+        with io.BytesIO(audio_bytes) as buf:
+            data, samplerate = sf.read(buf, always_2d=False)
+        return data, samplerate
+    else:
+        # Assume it's a file path
+        if audio_source.startswith("file://"):
+            audio_source = audio_source[len("file://") :]
+        data, samplerate = sf.read(audio_source, always_2d=False)
+        return data, samplerate
+
+def encode_audio_data(audio_data: np.ndarray, sample_rate: int, mime_subtype: str = "wav") -> str:
+    """Encodes a numpy array into a base64 data URL."""
+    with io.BytesIO() as buf:
+        sf.write(buf, audio_data, sample_rate, format=mime_subtype)
+        buf.seek(0)
+        encoded = base64.b64encode(buf.read()).decode("ascii")
+    return f"data:audio/{mime_subtype};base64,{encoded}"
+
+
+@register_tool
+class AudioCropTool(BaseTool):
+    tool_type = "audio_crop"
+    timeout = TIMEOUT
+    function_spec = AUDIO_CROP_FUNCTION_SPEC
+    stop_tokens = ["</tool_call>"]
+
+    def get_usage_inst(self) -> str:
+        return (
+            'Crop an audio segment with <tool_call>{"name": "audio_crop", "arguments": '
+            '{"target_audio": 1, "time_window": [start_sec, end_sec]}}</tool_call>. '
+            'Time is measured in seconds and audio indices are 1-based.'
+        )
+
+    def load_env(self, trajectory_id):
+        env = super().load_env(trajectory_id)
+        # use [] as a placeholder for now,
+        # will try to load from extra_field later
+        env["audios"] = []
+        return env
+
+    def parse_action(self, action: str):
+        if not isinstance(action, str):
+            return {}, False
+
+        payload: Optional[Dict[str, Any]] = None
+        match = re.search(r"<tool_call>(.*?)</tool_call>", action, re.DOTALL)
+        if match:
+            try:
+                payload = json.loads(match.group(1).strip())
+            except json.JSONDecodeError:
+                payload = None
+        else:
+            try:
+                data = json.loads(action)
+                if isinstance(data, dict):
+                    payload = data
+            except json.JSONDecodeError:
+                payload = None
+
+        if not isinstance(payload, dict):
+            return {}, False
+
+        name = payload.get("name") or payload.get("tool_name")
+        if not isinstance(name, str) or name not in VALID_CALL_NAMES:
+            return {}, False
+
+        arguments = payload.get("arguments", {})
+        if not isinstance(arguments, dict):
+            return {}, False
+
+        return {"name": "audio_crop", "arguments": arguments}, True
+
+    def _extract_audios_from_extra_field(self, extra_field: Dict[str, Any]) -> None:
+        if isinstance(extra_field, dict) and isinstance(extra_field.get("audios"), list):
+            return extra_field["audios"]
+        return []
+
+    def _parse_time_window(self, value: Any) -> Tuple[float, float]:
+        if not isinstance(value, (list, tuple)) or len(value) != 2:
+            raise ValueError("time_window must be a list of two numbers.")
+        start_raw, end_raw = value
+        try:
+            start = float(start_raw)
+            end = float(end_raw)
+        except (TypeError, ValueError):
+            raise ValueError("time_window values must be numeric.")
+        if not math.isfinite(start) or not math.isfinite(end):
+            raise ValueError("time_window values must be finite.")
+        if end <= start:
+            raise ValueError("time_window end must be greater than start.")
+        if (end - start) < MIN_CROP_DURATION_SECONDS:
+            raise ValueError(
+                f"time_window duration {end - start:.2f}s is below the minimum {MIN_CROP_DURATION_SECONDS:.2f}s."
+            )
+        return start, end
+
+    def _parse_target_audio(self, value: Any, max_index: int) -> int:
+        try:
+            idx = int(value)
+        except (TypeError, ValueError):
+            raise ValueError("target_audio must be an integer.")
+        if idx <= 0 or idx > max_index:
+            raise ValueError(f"target_audio must be between 1 and {max_index}.")
+        return idx
+
+    def conduct_action(self, trajectory_id, action, extra_field):
+        parsed_action, is_valid = self.parse_action(action)
+        env = self.load_env(trajectory_id)
+        extra_field = extra_field or {}
+
+        if len(env["audios"]) == 0:
+            # try to extract audios from extra_field
+            env["audios"] = self._extract_audios_from_extra_field(extra_field)
+
+        if not is_valid:
+            observation = "Invalid audio crop request."
+            done = False
+            valid = False
+            self.update_env(trajectory_id, env, parsed_action, is_valid, extra_field, observation)
+            self.save_env(trajectory_id, env)
+            return observation, done, valid
+
+        if not env["audios"]:
+            observation = "No audio sources supplied for cropping."
+            done = False
+            valid = False
+            self.update_env(trajectory_id, env, parsed_action, False, extra_field, observation)
+            self.save_env(trajectory_id, env)
+            return observation, done, valid
+
+        arguments = parsed_action.get("arguments", {})
+        try:
+            time_window = self._parse_time_window(arguments.get("time_window"))
+            target_audio_idx = self._parse_target_audio(arguments.get("target_audio"), len(env["audios"]))
+        except ValueError as exc:
+            observation = f"Audio crop arguments error: {exc}"
+            done = False
+            valid = False
+            self.update_env(trajectory_id, env, parsed_action, False, extra_field, observation)
+            self.save_env(trajectory_id, env)
+            return observation, done, valid
+
+        try:
+            # 1. Select and decode the target audio
+            selected_audio_source: dict = env["audios"][target_audio_idx - 1]
+            audio_source = _resolve_audio_source(selected_audio_source)
+            audio_data, sample_rate = decode_audio_url(audio_source)
+
+            audio_array = np.asarray(audio_data)
+            if audio_array.ndim == 1:
+                audio_array = audio_array[:, np.newaxis]  # (samples, 1)
+            elif audio_array.ndim == 2:
+                # Ensure time dimension is first: (samples, channels)
+                if audio_array.shape[0] < audio_array.shape[1]:
+                    audio_array = audio_array.T
+            else:
+                raise ValueError(f"Unsupported audio data shape: {audio_array.shape}")
+
+            total_samples = audio_array.shape[0]
+
+            # 2. Perform the crop in-memory
+            start_sec, end_sec = time_window
+            start_frame = int(np.round(start_sec * sample_rate))
+            end_frame = int(np.round(end_sec * sample_rate))
+
+            # Clamp the frames to be within the audio's bounds
+            start_frame_clamped = max(0, min(start_frame, total_samples))
+            end_frame_clamped = max(0, min(end_frame, total_samples))
+
+            if end_frame_clamped <= start_frame_clamped:
+                raise ValueError("Cropped segment duration is zero or negative.")
+
+            cropped_data = audio_array[start_frame_clamped:end_frame_clamped]
+            if cropped_data.size == 0:
+                raise ValueError("Cropped segment is empty after slicing.")
+
+            # Preserve mono shape for encoding
+            if cropped_data.ndim == 2 and cropped_data.shape[1] == 1:
+                cropped_to_encode = cropped_data[:, 0]
+            else:
+                cropped_to_encode = cropped_data
+
+            actual_start = start_frame_clamped / float(sample_rate)
+            actual_end = end_frame_clamped / float(sample_rate)
+            actual_duration = cropped_data.shape[0] / float(sample_rate)
+            if actual_duration < MIN_CROP_DURATION_SECONDS:
+                raise ValueError(
+                    f"Cropped audio is only {actual_duration:.2f}s, shorter than the minimum "
+                    f"{MIN_CROP_DURATION_SECONDS:.2f}s required. Please request a longer time window."
+                )
+
+            # 3. Encode the cropped data back to a data URL
+            new_data_uri = encode_audio_data(cropped_to_encode, sample_rate)
+            
+            # 4. Append the new audio to the environment
+            env["audios"].append(new_data_uri)
+            new_index = len(env["audios"])
+
+            # 5. Create the observation
+            obs_text = (
+                f"<audio>This is the audio clip ({actual_start:.2f}s - {actual_end:.2f}s) from the original audio #{target_audio_idx} according to your request."
+            )
+            observation = {
+                "obs": obs_text,
+                "audio": new_data_uri,
+            }
+            done = False
+            valid = True
+        except Exception as exc:
+            observation = f"Audio crop failed: {exc}"
+            done = False
+            valid = False
+
+        self.update_env(trajectory_id, env, parsed_action, valid, extra_field, observation)
+        self.save_env(trajectory_id, env)
+        return observation, done, valid

--- a/verl_tool/utils/dataset/audio_utils.py
+++ b/verl_tool/utils/dataset/audio_utils.py
@@ -1,0 +1,39 @@
+from io import BytesIO
+from typing import Optional
+
+import torch
+import numpy
+from PIL import Image
+from qwen_omni_utils import process_audio_info, process_mm_info
+
+import librosa
+import base64
+from pathlib import Path
+import soundfile as sf
+
+SAMPLE_RATE = 16000
+
+def process_audio(audio: dict) -> numpy.ndarray:
+    assert ("audio" in audio or "audio_url" in audio), "audio is not found in the audio dictionary"
+    
+    audio["type"] = "audio"
+    dummy_content = [audio]
+    dummy_message = {"role": "user", "content": dummy_content}
+    dummy_conversation = [dummy_message]
+    return process_audio_info(dummy_conversation, use_audio_in_video=False)[0]
+
+def encode_audio_file(audio_path: str, mime_subtype: str = "wav") -> str:
+    with Path(audio_path).open("rb") as file_obj:
+        encoded = base64.b64encode(file_obj.read()).decode("ascii")
+    return f"data:audio/{mime_subtype};base64,{encoded}"
+
+def encode_audio_data(audio_data: numpy.ndarray, sample_rate: int = SAMPLE_RATE, mime_subtype: str = "wav") -> str:
+    """Encodes audio data from a numpy array into a base64 data URL."""
+    with BytesIO() as buf:
+        sf.write(buf, audio_data, sample_rate, format=mime_subtype)
+        buf.seek(0)
+        encoded = base64.b64encode(buf.read()).decode("ascii")
+    return f"data:audio/{mime_subtype};base64,{encoded}"
+
+def decode_audio_url(audio_url: str) -> str:
+    return process_audio({"audio_url": audio_url})

--- a/verl_tool/workers/reward_manager/audio.py
+++ b/verl_tool/workers/reward_manager/audio.py
@@ -1,0 +1,235 @@
+import torch
+import numpy as np
+from collections import defaultdict
+
+from verl import DataProto
+from verl.workers.reward_manager import register
+
+
+def normalize_solution(solution_str):
+    # be careful with the escape characters!
+    if r"\boxed{" in solution_str:
+        # extract solution from \boxed{...}
+        solution_str = solution_str.split(r"\boxed{")[-1].split("}")[0]
+    return solution_str
+
+
+def is_contained(target, source):
+    if target in source:
+        return True
+    return False
+
+
+def audio_compute_score(solution_str, ground_truth):
+    if isinstance(ground_truth, list):
+        return max([audio_compute_score(solution_str, gt) for gt in ground_truth])
+
+    solution_str = normalize_solution(solution_str)
+    if not solution_str or not ground_truth:
+        # either solution_str or ground_truth is invalid
+        return 0.0
+
+    verify_result = is_contained(
+        solution_str.lower().strip(),
+        ground_truth.lower().strip()
+    )
+    if verify_result:
+        return 1.0
+    else:
+        return 0.0
+
+
+@register("audio")
+class AudioRewardManager:
+    name = "audio" # reward manager identifier
+    
+    def __init__(self, tokenizer, num_examine, compute_score=None, reward_fn_key='data_source', **kwargs):
+        self.tokenizer = tokenizer
+        self.num_examine = num_examine
+        self.compute_score = audio_compute_score
+        self.reward_fn_key = reward_fn_key
+
+        # ----------
+        # curiosity penalty
+        self.add_curiousity_reward = True
+        self.group_tool_call_rate_lower_bound = 0.3
+        self.alpha = 0.5
+        # ----------
+        # execution penalty
+        self.add_tool_exec_penalty = True
+        # ----------
+
+    def add_additional_penalties(self, response: str, data_i, scores_i: dict, group_info:dict):
+        """
+            compute additional penalities:
+            - curiosity_penalty: incentivize the model to explore tool-using more often
+            - execution penalty: penalize the model for incorrect tool-using
+        """
+        if "tool_interact_info" in data_i.non_tensor_batch:
+            tool_interact_info = data_i.non_tensor_batch.get('tool_interact_info', None)
+            num_turn = len(tool_interact_info) if tool_interact_info is not None else 0
+            num_valid_action = sum([1 for t in tool_interact_info if t.get('valid_action', False)]) if tool_interact_info is not None else 0
+
+            if self.add_curiousity_reward:
+                # penalize the model if group_tool_call_rate is 
+                # less than group_tool_call_rate_lower_bound
+                curiosity_reward = group_info.get('group_tool_call_rate', 0.0) - self.group_tool_call_rate_lower_bound
+                curiosity_reward *= self.alpha
+                scores_i['score'] += curiosity_reward
+                scores_i['group_tool_call_lower_bound'] = self.group_tool_call_rate_lower_bound
+                scores_i['group_tool_call_rate'] = group_info.get('group_tool_call_rate', 0.0)
+                scores_i['curiosity_reward'] = curiosity_reward
+
+            if self.add_tool_exec_penalty:
+                keywords = ["error", "failed"]
+                if any(keyword in response.lower() for keyword in keywords):
+                    scores_i['score'] -= 0.1
+                    scores_i['exec_error'] = 1
+                else:
+                    scores_i['exec_error'] = 0
+
+        return scores_i
+
+    def get_group_info(self, data: DataProto):
+        """
+            get group information:
+            - num_turns
+            - num_valid_actions
+            - group_tool_call_rate
+            - tool_call_total
+        """
+        group_info = {}
+        for i in range(len(data)):
+            data_item = data[i]  # DataProtoItem
+            tool_interact_info = data_item.non_tensor_batch.get('tool_interact_info', None)
+            num_turn = len(tool_interact_info) if tool_interact_info is not None else 0
+            num_valid_action = sum([1 for t in tool_interact_info if t.get('valid_action', False)]) if tool_interact_info is not None else 0
+            if "tool_interact_info" in data_item.non_tensor_batch:
+                uid = data_item.non_tensor_batch.get('uid', i)
+                if uid not in group_info:
+                    group_info[uid] = {}
+                if 'num_turns' not in group_info[uid]:
+                    group_info[uid]['num_turns'] = []
+                if 'num_valid_actions' not in group_info[uid]:
+                    group_info[uid]['num_valid_actions'] = []
+                group_info[uid]['num_turns'].append(num_turn)
+                group_info[uid]['num_valid_actions'].append(num_valid_action)
+        for uid, info in group_info.items():
+            info['num_turns'] = np.array(info['num_turns'])
+            info['num_valid_actions'] = np.array(info['num_valid_actions'])
+            info['group_tool_call_rate'] = np.mean([1 if num_valid_action > 0 else 0 for num_valid_action in info['num_valid_actions']])
+            info['tool_call_total'] = info['num_valid_actions'].sum()
+        return group_info
+
+    def __call__(self, data: DataProto, return_dict=False):
+        """We will expand this function gradually based on the available datasets"""
+        # If there is rm score, we directly return rm score. Otherwise, we compute via rm_score_fn
+        if 'rm_scores' in data.batch.keys():
+            if return_dict:
+                return {"reward_tensor": data.batch['rm_scores']}
+            else:
+                return data.batch['rm_scores']
+
+        reward_tensor = torch.zeros_like(data.batch['responses'], dtype=torch.float32)
+        reward_extra_info = defaultdict(list)
+
+        already_print_data_sources = {}
+
+        group_info = self.get_group_info(data)
+        for i in range(len(data)):
+            score = {}
+            data_item = data[i]  # DataProtoItem
+
+            prompt_ids = data_item.batch['prompts']
+
+            prompt_length = prompt_ids.shape[-1]
+
+            valid_prompt_length = data_item.batch['attention_mask'][:prompt_length].sum()
+            valid_prompt_ids = prompt_ids[-valid_prompt_length:]
+
+            response_ids = data_item.batch['responses']
+            valid_response_length = data_item.batch['attention_mask'][prompt_length:].sum()
+            valid_response_ids = response_ids[:valid_response_length]
+            if "loss_mask" in data_item.batch:
+                loss_mask = data_item.batch['loss_mask']
+                valid_response_ids_with_loss_mask = torch.where(loss_mask[prompt_length:prompt_length + valid_response_length] == 1, valid_response_ids, self.tokenizer.pad_token_id)
+            else:
+                valid_response_ids_with_loss_mask = valid_response_ids
+
+            # decode
+            prompt_str = self.tokenizer.decode(valid_prompt_ids, skip_special_tokens=True)
+            response_str = self.tokenizer.decode(valid_response_ids, skip_special_tokens=True)
+
+            ground_truth = data_item.non_tensor_batch['reward_model']['ground_truth']
+
+            data_source = data_item.non_tensor_batch[self.reward_fn_key]
+
+            extra_info = data_item.non_tensor_batch.get('extra_info', None)
+
+            torl_score = self.compute_score(
+                solution_str=response_str,
+                ground_truth=ground_truth,
+            ) # 1.0 or 0.0
+            score['accuracy'] = 1 if torl_score > 0 else 0
+            score['score'] = torl_score
+
+            # add additional penalty
+            score = self.add_additional_penalties(response_str, data_item, score, group_info.get(data_item.non_tensor_batch.get('uid', i), {}))      
+
+            if score['accuracy'] > 0:
+                reward_extra_info['correct_response_length'].append(valid_response_length)
+            else:
+                reward_extra_info['wrong_response_length'].append(valid_response_length)
+
+            if isinstance(score, dict):
+                reward = score["score"]
+                # Store the information including original reward
+                for key, value in score.items():
+                    reward_extra_info[key].append(value)
+                if self.num_examine == 1:
+                    reward = score["accuracy"] # for validation
+            else:
+                if self.num_examine == 1:
+                    reward = score if score > 0 else 0.0
+                else:
+                    reward = score
+
+            reward_tensor[i, valid_response_length - 1] = reward 
+
+            if data_source not in already_print_data_sources:
+                already_print_data_sources[data_source] = 0
+
+            if already_print_data_sources[data_source] < self.num_examine:
+                already_print_data_sources[data_source] += 1
+                print("[prompt]", prompt_str)
+                print("[response]", response_str)
+                print("[ground_truth]", ground_truth)
+                if isinstance(score, dict):
+                    for key, value in score.items():
+                        print(f"[{key}]", value)
+                else:
+                    print(f"[score]", score)
+                    
+            # Save the records
+            tool_interact_info_i = data_item.non_tensor_batch.get('tool_interact_info', None)
+            if tool_interact_info_i is not None:
+                # crop the image
+                for tool_interact in tool_interact_info_i:
+                    if "image" in tool_interact:
+                        if isinstance(tool_interact['image'], list):
+                            tool_interact['image'] = [x[:50] for x in tool_interact['image']]  # crop the image to first 50 characters
+                        elif isinstance(tool_interact['image'], str):
+                            tool_interact['image'] = tool_interact['image'][:50] # for debug
+            
+        correct_response_length_mean = np.mean(reward_extra_info['correct_response_length']) if reward_extra_info['correct_response_length'] else 0.0
+        wrong_response_length_mean = np.mean(reward_extra_info['wrong_response_length']) if reward_extra_info['wrong_response_length'] else 0.0
+        reward_extra_info['correct_response_length'] = [correct_response_length_mean] * len(reward_tensor)
+        reward_extra_info['wrong_response_length'] = [wrong_response_length_mean] * len(reward_tensor)
+
+        if return_dict:
+            return {
+                "reward_tensor": reward_tensor,
+                "reward_extra_info": dict(sorted(reward_extra_info.items())),
+            }
+        else:
+            return reward_tensor

--- a/verl_tool/workers/rollout/vllm_rollout/vllm_async_server.py
+++ b/verl_tool/workers/rollout/vllm_rollout/vllm_async_server.py
@@ -1,10 +1,9 @@
 import ray
-import uuid
+import numpy as np
 from verl.workers.rollout.vllm_rollout.vllm_async_server import (
     vLLMHttpServerBase,
     SamplingParams, 
     TokensPrompt, 
-    _qwen2_5_vl_dedup_image_tokens,
     RolloutConfig,
     RewardModelConfig,
     HFModelConfig,
@@ -50,6 +49,7 @@ class VerlToolvLLMHttpServer(vLLMHttpServerBase):
         sampling_params: dict[str, Any],
         request_id: str,
         image_data: Optional[list[Any]] = None,
+        audio_data: Optional[list[Any]] = None,
     ) -> VerlToolTokenOutput:
         """Generate sequence with token-in-token-out."""
         # TODO(@wuxibin): switch to `/generate` http endpoint once multi-modal support ready.
@@ -58,9 +58,15 @@ class VerlToolvLLMHttpServer(vLLMHttpServerBase):
         sampling_params["logprobs"] = 0 if sampling_params.pop("logprobs", False) else None
         sampling_params.setdefault("repetition_penalty", self.config.get("repetition_penalty", 1.0))
         sampling_params = SamplingParams(**sampling_params)
-        prompt_ids = _qwen2_5_vl_dedup_image_tokens(prompt_ids, self.model_config.processor)
+        prompt_ids = _qwen2_5_dedup_multimodal_tokens(prompt_ids, self.model_config.processor)
+        
+        multi_modal_data: dict[str, Any] = {}
+        if image_data:
+            multi_modal_data["image"] = image_data
+        if audio_data:
+            multi_modal_data["audio"] = audio_data
         prompt = TokensPrompt(
-            prompt_token_ids=prompt_ids, multi_modal_data={"image": image_data} if image_data else None
+            prompt_token_ids=prompt_ids, multi_modal_data=multi_modal_data or None
         )
 
         # Add lora request
@@ -93,3 +99,54 @@ class VerlToolvLLMHttpServer(vLLMHttpServerBase):
         finished = final_res.finished
 
         return VerlToolTokenOutput(token_ids=token_ids, log_probs=log_probs, finish_reason=finish_reason, stop_reason=stop_reason, text=text, finished=finished)
+
+
+def _qwen2_5_dedup_multimodal_tokens(prompt_ids: list[int], processor):
+    """Deduplicate consecutive image and *audio* tokens in prompt_ids for Qwen2.5-VL/Omni, since vLLM will replicate the
+    <|image_pad|> token by image_data and <|AUDIO|> token by audio_data.
+
+    For example,
+    ```
+    <|vision_start|><|image_pad|><|image_pad|>...<|image_pad|><|vision_end|>
+    =>
+    <|vision_start|><|image_pad|><|vision_end|>
+    
+    <|audio_bos|><|AUDIO|><|AUDIO|>...<|AUDIO|><|audio_eos|>
+    =>
+    <|audio_bos|><|AUDIO|><|audio_eos|>
+    ```
+    """
+    if processor is None:
+        return prompt_ids
+    
+    # Check for Qwen2_5OmniProcessor (needs to get image_token_id from tokenizer)
+    is_qwen2_5_omni = "Qwen2_5OmniProcessor" in processor.__class__.__name__
+    # Check for Qwen2VLImageProcessor (has image_token_id attribute)
+    is_qwen2vl = not is_qwen2_5_omni and "Qwen2VLImageProcessor" in processor.image_processor.__class__.__name__
+    
+    if is_qwen2vl or is_qwen2_5_omni:
+        prompt_ids = np.array(prompt_ids)
+
+        # Create a mask where True indicates elements to keep
+        mask = np.ones(len(prompt_ids), dtype=bool)
+
+        # Get image_token_id based on processor type
+        if is_qwen2vl:
+            # Qwen2VLImageProcessor has image_token_id attribute
+            image_token_id = processor.image_token_id
+        else:
+            # Qwen2_5OmniProcessor: get image_token_id from tokenizer
+            image_token_id = processor.tokenizer.image_token_id
+
+        # Deduplicate consecutive image tokens
+        is_image_token = prompt_ids == image_token_id
+        mask[1:] &= ~(is_image_token[1:] & is_image_token[:-1])
+
+        # For Qwen2_5OmniProcessor, also deduplicate consecutive audio tokens
+        audio_token_id = processor.tokenizer.audio_token_id
+        is_audio_token = prompt_ids == audio_token_id
+        mask[1:] &= ~(is_audio_token[1:] & is_audio_token[:-1])
+
+        return prompt_ids[mask].tolist()
+    else:
+        return prompt_ids


### PR DESCRIPTION
Key modifications:
- verl_tool/agent_loop/agent_loop.py
- verl_tool/agent_loop/verltool_agent_loop.py
- verl_tool/workers/rollout/vllm_rollout/vllm_async_server.py

Addtional Supports:
- necessary audio utils: verl_tool/utils/dataset/audio_utils.py
- patch for verl: since verl currently does not support qwen2.5-omni and auditory input, we made a patch (patches/qwen_2_5_omni.patch) for it
- examples/{train,data_preproces}/mmau_pro: we provide some examples for preparing and training qwen2.5-omni model on mmau_pro dataset
- a new reward manager: see verl_tool/workers/reward_manager/audio.py
- a new audio tool: verl_tool/servers/tools/audio_crop.py
