### PR TITLE
fix: (1) strip whitespace when parsing action_stop_tokens (2) avoid truncation could split multimodal placeholder token sequences 

### DIFF
--- a/verl_tool/agent_loop/verltool_agent_loop.py
+++ b/verl_tool/agent_loop/verltool_agent_loop.py
@@ -802,9 +802,11 @@ class VerlToolAgentLoop(AgentLoopBase):
             response_mask = response_mask[:cut_index]
             response_logprobs = response_logprobs[:cut_index]
 
-        # 保证图片与 token 一一对应，防止 Qwen3-VL 等模型在 tokens/features 数量不一致时报错。
-        # 这里只统计最终会送进模型的 token（prompt_ids + 截断后的 response_ids），
-        # 并以 <|vision_start|> 的出现次数近似为可用图片段数量。
+        # Keep image features aligned with tokens to avoid tokens/features mismatch
+        # errors in models such as Qwen3-VL.
+        # Count only the tokens that will actually be fed to the model
+        # (prompt_ids + truncated response_ids), and approximate available image
+        # segments by counting contiguous token: <|vision_start|>
         if running_image_data is not None:
             full_ids = prompt_ids + response_ids
             vision_start_id = self.tokenizer.convert_tokens_to_ids("<|vision_start|>")


### PR DESCRIPTION
## Problem1
When configuring `action_stop_tokens` with comma-separated values like:`action_stop_tokens='</code>, </search>'`
The parser was not stripping whitespace, resulting in:
Token 1: `</code>` ✅
Token 2: ` </search>` ❌ (with leading space)
This caused the model to fail to stop at </search>, leading to incorrect behavior.

## Solution1
Modified the token parsing logic in verltool_agent_loop.py (line 173) to strip whitespace:
```python
# Before
cls.action_stop_tokens = [x for x in f.read().split(',') if x]

# After  
cls.action_stop_tokens = [x.strip() for x in f.read().split(',') if x.strip()]
```
## Problem1
Similar to bugs identified in https://github.com/verl-project/verl/issues/4050.
When truncating agent responses to fit within `response_length` limits, the truncation could split multimodal placeholder token sequences (e.g., `<|vision_start|><|image_pad|><|vision_end|>`) in the middle. This causes lots of issues.

## Solution2
When truncating responses by response_length, walk backwards to avoid cutting multimodal placeholder tokens (e.g., <|vision_start|>,  <|image_pad|>, <|vision_end|>, <|audio_bos|>, etc.) in half.

This ensures that multimodal token sequences are either kept completely or discarded as complete blocks, preventing token corruption that could cause model errors during training.